### PR TITLE
[Hardware-Wallet]: Create the Linux configuration file automatically

### DIFF
--- a/tiny-firmware/README.md
+++ b/tiny-firmware/README.md
@@ -29,6 +29,12 @@ sudo apt-get install protobuf-compiler python-protobuf golang-goprotobuf-dev
 
 We need to tell your kernel to use the [hidraw module](https://www.kernel.org/doc/Documentation/hid/hidraw.txt) to communicate with the hardware device. If you don't your kernel will treat the device as a mouse or a keyboard.
 
+#### Automatically
+
+Run `sudo ./prepare-sky-hw.sh`.
+
+#### Manually
+
 Create a file named 99-dev-kit.rules in your /etc/udev/rules.d/ folder and write this content in that file (*super user priviledges are required for this step*).
 
     ## 0483:df11 STMicroelectronics STM Device in DFU Mode

--- a/tiny-firmware/prepare-sky-hw.sh
+++ b/tiny-firmware/prepare-sky-hw.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+cat <<EOF >/etc/udev/rules.d/99-dev-kit.rules
+## 0483:df11 STMicroelectronics STM Device in DFU Mode
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="df11", MODE="0666"
+## 0483:3748 STMicroelectronics ST-LINK/V2
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3748", MODE="0666"
+## 0483:374b STMicroelectronics ST-LINK/V2.1 (Nucleo-F103RB)
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="374b", MODE="0666"
+## 313a:0001
+SUBSYSTEM=="usb", ATTR{idVendor}=="313a", ATTR{idProduct}=="0001", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="313a", ATTRS{idProduct}=="0001", MODE="0666"
+EOF
+
+udevadm control --reload-rules
+udevadm trigger


### PR DESCRIPTION
@mpsido This PR adds a file named `prepare-sky-hw.sh` that allows to automatically create the configuration file described in https://github.com/skycoin/hardware-wallet/tree/master/tiny-firmware#configure-your-usb-module. The idea is that end users can use that file to configure the system easily, instead of having to manually create/modify system files.

In my tests I saw that only the two configuration lines below `## 313a:0001` are necessary, but, just in case, the created file is the same as the one described in the README. If the other lines are not necessary, it would be good to delete them.

The README was updated.