### PR TITLE
fixes #48 - Tiny firmware setup instructions for macos (round 2)

### DIFF
--- a/tiny-firmware/README.md
+++ b/tiny-firmware/README.md
@@ -25,19 +25,31 @@ sudo apt-get install arm-none-eabi-gcc
 On Mac OS, after [installing homebrew](https://docs.brew.sh/Installation) it is recommended to install the toolchain like this
 
 ```sh
-brew tap simelo/homebrew-px4
+brew tap simelo/homebrew-skycoin
 brew update
 brew install gcc-arm-none-eabi-63
 ```
 
 ### Install ST-LINK
 
-Follow the steps [here](https://github.com/texane/stlink/blob/master/doc/compiling.md).
+[ST-LINK](https://github.com/texane/stlink) tool is needed to send JTAG commands to the Skycoin hardware wallet.
+Binaries are available for [installing ST-LINK using native package managers](https://github.com/texane/stlink#installation).
+If this option is not available for the platform of your preference then install from sources
+by following the steps [here](https://github.com/texane/stlink/blob/master/doc/compiling.md).
 
 ### Install google protobuf
 
+On GNU/Linux
+
 ```
 sudo apt-get install protobuf-compiler python-protobuf golang-goprotobuf-dev
+```
+
+On Mac OS
+
+```
+brew install protobuf --with-python
+go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
 ```
 
 ### Configure your usb module

--- a/tiny-firmware/README.md
+++ b/tiny-firmware/README.md
@@ -25,7 +25,7 @@ sudo apt-get install arm-none-eabi-gcc
 On Mac OS, after [installing homebrew](https://docs.brew.sh/Installation) it is recommended to install the toolchain like this
 
 ```sh
-brew tap simelo/homebrew-skycoin
+brew tap skycoin/homebrew-skycoin
 brew update
 brew install gcc-arm-none-eabi-63
 ```

--- a/tiny-firmware/README.md
+++ b/tiny-firmware/README.md
@@ -39,7 +39,7 @@ by following the steps [here](https://github.com/texane/stlink/blob/master/doc/c
 
 ### Install google protobuf
 
-On GNU/Linux
+On Debian and Ubuntu GNU/Linux
 
 ```
 sudo apt-get install protobuf-compiler python-protobuf golang-goprotobuf-dev
@@ -51,6 +51,12 @@ On Mac OS
 brew install protobuf --with-python
 go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
 ```
+
+If no binaries are available for your platform then
+
+- [Install Protobuf C++ runtime and protoc](https://github.com/protocolbuffers/protobuf/tree/master/src) from sources.
+- [Install Protobuf Python runtime](https://github.com/protocolbuffers/protobuf/tree/master/python#installation) from sources.
+- [Install Protobuf Go runtime](https://github.com/golang/protobuf#installation) from sources.
 
 ### Configure your usb module
 

--- a/tiny-firmware/README.md
+++ b/tiny-firmware/README.md
@@ -34,6 +34,12 @@ brew install gcc-arm-none-eabi-63
 
 [ST-LINK](https://github.com/texane/stlink) tool is needed to send JTAG commands to the Skycoin hardware wallet.
 Binaries are available for [installing ST-LINK using native package managers](https://github.com/texane/stlink#installation).
+For instance, on Mac OS X the following command will install `stlink` and its dependencies.
+
+```
+brew install stlink
+```
+
 If this option is not available for the platform of your preference then install from sources
 by following the steps [here](https://github.com/texane/stlink/blob/master/doc/compiling.md).
 


### PR DESCRIPTION
Fixes #48 

Changes:
- Install `gcc-arm-none-eabi-63` from `skycoin/homebrew-skycoin` tap
- Recommend `brew install stlink`
- Instructions to install protobuf from sources (last recourse alternative)