### PR TITLE
[firmware] fixes #78 #91 - Coin fractions in Skywallet display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@
 
 UNAME_S ?= $(shell uname -s)
 
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MKFILE_DIR  := $(dir $(MKFILE_PATH))
+
 VERSION_FIRMWARE         ?= $(shell cat tiny-firmware/VERSION)
 VERSION_FIRMWARE_MAJOR   ?= $(shell cat tiny-firmware/VERSION | cut -d. -f1)
 VERSION_FIRMWARE_MINOR   ?= $(shell cat tiny-firmware/VERSION | cut -d. -f2)
@@ -17,6 +20,12 @@ VERSION_BOOTLOADER       ?= $(shell cat tiny-firmware/bootloader/VERSION)
 VERSION_BOOTLOADER_MAJOR ?= $(shell cat tiny-firmware/bootloader/VERSION | cut -d. -f1)
 VERSION_BOOTLOADER_MINOR ?= $(shell cat tiny-firmware/bootloader/VERSION | cut -d. -f2)
 VERSION_BOOTLOADER_PATCH ?= $(shell cat tiny-firmware/bootloader/VERSION | cut -d. -f3)
+
+ifeq ($(UNAME_S), Darwin)
+	LD_VAR=DYLD_LIBRARY_PATH
+else
+	LD_VAR=LD_LIBRARY_PATH
+endif
 
 install-linters-Darwin:
 	brew install yamllint
@@ -143,6 +152,8 @@ run-emulator: emulator ## Run wallet emulator
 	./emulator
 
 test: ## Run all project test suites.
+	export LIBRARY_PATH="$(MKFILE_DIR)/skycoin-api/:$$LIBRARY_PATH"
+	export $(LD_VAR)="$(MKFILE_DIR)/skycoin-api/:$$$(LD_VAR)"
 	make -C skycoin-api/ test
 	make emulator
 	EMULATOR=1 make -C tiny-firmware/ test

--- a/skycoin-api/skycoin_crypto.h
+++ b/skycoin-api/skycoin_crypto.h
@@ -16,8 +16,8 @@
 #include <stddef.h>
 
 typedef struct TransactionOutput{
-    uint32_t coin;
-    uint32_t hour;
+    uint64_t coin;
+    uint64_t hour;
     uint8_t address[20];
 }TransactionOutput;
 

--- a/tiny-firmware/Makefile
+++ b/tiny-firmware/Makefile
@@ -54,6 +54,7 @@ OBJS += firmware/trezor.o
 OBJS += firmware/layout2.o
 OBJS += firmware/storage.o
 OBJS += firmware/messages.o
+OBJS += firmware/droplet.o
 OBJS += firmware/fsm.o
 OBJS += firmware/fsm_impl.o
 OBJS += firmware/protect.o

--- a/tiny-firmware/Makefile
+++ b/tiny-firmware/Makefile
@@ -25,6 +25,12 @@ endif
 OBJS += gen/fonts.o
 #end libtrezor.a
 
+#test_skyhw
+TEST_OBJS += firmware/test_fsm.o
+TEST_OBJS += firmware/test_droplet.o
+TEST_OBJS += firmware/test_main.o
+#end test_skyhw
+
 ifneq ($(EMULATOR),1)
 LDSCRIPT  = memory.ld
 LDLIBS   += -lopencm3_stm32f2

--- a/tiny-firmware/Makefile.include
+++ b/tiny-firmware/Makefile.include
@@ -173,8 +173,8 @@ ifeq ($(UNAME_S), Darwin)
 	TESTLIBS=$(TESTLIBS_DARWIN)
 endif
 
-test_$(NAME): proto lib$(NAME).a firmware/test_fsm.o
-	$(LD) -o test_$(NAME) firmware/test_fsm.o $(OBJS) $(LDLIBS) $(LDFLAGS) $(TESTLIBS)
+test_$(NAME): proto lib$(NAME).a $(TEST_OBJS)
+	$(LD) -o test_$(NAME) $(TEST_OBJS) $(OBJS) $(LDLIBS) $(LDFLAGS) $(TESTLIBS)
 
 test: test_$(NAME) ## Run test suite for tiny-firmware.
 	./test_$(NAME)

--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -12,6 +12,11 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     mod = div % 10;
     div = div / 10;
   }
+  if (precision_exp > 0) {
+    *ptr = '0' + mod;
+    --ptr;
+    --sz;
+  }
   // Print decimal digits
   for (; div > 0 && precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
     mod = div % 10;
@@ -22,20 +27,21 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     // No space left in buffer
     return NULL;
   }
-  if (*ptr != 0) {
+  if (ptr != eos) {
     // Not an integer value
     *ptr = '.';
-    if (--sz == 0) {
+    if ((--sz) == 0) {
       return NULL;
     }
     --ptr;
   }
+  // A fraction of 1 SKY
   if (div == 0) {
     *ptr = '0';
     return ptr;
   }
   // Print integer part
-  for (--ptr, --sz; div > 0 && sz > 0; --sz, --ptr) {
+  for (; div > 0 && sz > 0; --sz, --ptr) {
     mod = div % 10;
     div = div / 10;
     *ptr = '0' + mod;

--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -31,7 +31,7 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     }
   }
   // Print decimal digits
-  for (; div > 0 && precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
+  for (; precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
     mod = div % 10;
     div = div / 10;
     *ptr = '0' + mod;

--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -29,7 +29,7 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     // No space left in buffer
     return NULL;
   }
-  if (ptr != eos + 1) {
+  if (*(ptr + 1) != 0) {
     // Not an integer value
     *ptr = '.';
     if ((--sz) == 0) {

--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -1,5 +1,6 @@
 
 #include "droplet.h"
+#include <stdio.h>
 
 char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
   uint64_t div, mod;
@@ -7,6 +8,16 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
   char* ptr = eos;
   // EOS
   *ptr = 0;
+  --sz;
+  // Trivial case handled differently for performance
+  if (coins == 0) {
+    if (sz > 0) {
+      *(--ptr) = '0';
+      return ptr;
+    } else {
+      return NULL;
+    }
+  }
   // Skip least significant decimal digits
   for (--ptr, div = coins, mod = 0; mod == 0 && precision_exp > 0; --precision_exp) {
     mod = div % 10;
@@ -15,7 +26,7 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
   if (precision_exp > 0) {
     *ptr = '0' + mod;
     --ptr;
-    if ((--sz) == 0) {
+    if ((--sz) <= 0) {
       return NULL;
     }
   }
@@ -25,14 +36,14 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     div = div / 10;
     *ptr = '0' + mod;
   }
-  if (sz == 0) {
+  if (sz <= 0) {
     // No space left in buffer
     return NULL;
   }
   if (*(ptr + 1) != 0) {
     // Not an integer value
     *ptr = '.';
-    if ((--sz) == 0) {
+    if ((--sz) <= 0) {
       return NULL;
     }
     --ptr;

--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -15,7 +15,9 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
   if (precision_exp > 0) {
     *ptr = '0' + mod;
     --ptr;
-    --sz;
+    if ((--sz) == 0) {
+      return NULL;
+    }
   }
   // Print decimal digits
   for (; div > 0 && precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
@@ -27,7 +29,7 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     // No space left in buffer
     return NULL;
   }
-  if (ptr != eos) {
+  if (ptr != eos + 1) {
     // Not an integer value
     *ptr = '.';
     if ((--sz) == 0) {

--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -1,0 +1,48 @@
+
+#include "droplet.h"
+
+char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
+  uint64_t div, mod;
+  char* eos = msg + sz;
+  char* ptr = eos;
+  // EOS
+  *ptr = 0;
+  // Skip least significant decimal digits
+  for (--ptr, div = coins, mod = 0; mod == 0 && precision_exp > 0; --precision_exp) {
+    mod = div % 10;
+    div = div / 10;
+  }
+  // Print decimal digits
+  for (; div > 0 && precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
+    mod = div % 10;
+    div = div / 10;
+    *ptr = '0' + mod;
+  }
+  if (sz == 0) {
+    // No space left in buffer
+    return NULL;
+  }
+  if (*ptr != 0) {
+    // Not an integer value
+    *ptr = '.';
+    if (--sz == 0) {
+      return NULL;
+    }
+    --ptr;
+  }
+  if (div == 0) {
+    *ptr = '0';
+    return ptr;
+  }
+  // Print integer part
+  for (--ptr, --sz; div > 0 && sz > 0; --sz, --ptr) {
+    mod = div % 10;
+    div = div / 10;
+    *ptr = '0' + mod;
+  }
+  if (div > 0) {
+    // No space left in buffer
+    return NULL;
+  }
+  return ++ptr;
+}

--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -31,10 +31,13 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     }
   }
   // Print decimal digits
-  for (; precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
+  for (; div > 0 && precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
     mod = div % 10;
     div = div / 10;
     *ptr = '0' + mod;
+  }
+  for (; precision_exp > 0 && sz > 0; --precision_exp, --sz, --ptr) {
+    *ptr = '0';
   }
   if (sz <= 0) {
     // No space left in buffer

--- a/tiny-firmware/firmware/droplet.h
+++ b/tiny-firmware/firmware/droplet.h
@@ -1,0 +1,13 @@
+
+#ifndef __DROPLET_H__
+#define __DROPLET_H__
+
+#include <stdint.h>
+#include <string.h>
+
+/**
+ * String representation of coins
+ */
+char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg);
+
+#endif

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -21,6 +21,7 @@
 #include <libopencm3/stm32/flash.h>
 
 #include <stdio.h>
+#include <inttypes.h>
 #include "trezor.h"
 #include "fsm.h"
 #include "messages.h"
@@ -295,7 +296,7 @@ void fsm_msgTransactionSign(TransactionSign* msg) {
 			msg->transactionIn[i].hashIn, msg->transactionIn[i].index);
 	}
 	for (uint32_t i = 0; i < msg->nbOut; ++i) {
-		printf("Output: coin: %d, hour: %d address: %s address_index: %d\n",
+		printf("Output: coin: %" PRIu64 ", hour: %" PRIu64 " address: %s address_index: %d\n",
 			msg->transactionOut[i].coin, msg->transactionOut[i].hour, 
 			msg->transactionOut[i].address, msg->transactionOut[i].address_index);
 	}
@@ -314,9 +315,9 @@ void fsm_msgTransactionSign(TransactionSign* msg) {
 		char* hourString = (msg->transactionOut[i].hour == 1 || msg->transactionOut[i].hour == 0) ? _("hour") : _("hours");
 		sprintf(strCoin, "%s %.2f %s",  _("send"), msg->transactionOut[i].coin / 1000000.00, coinString);
 #if EMULATOR
-		sprintf(strHour, "%u %s", msg->transactionOut[i].hour, hourString);
+		sprintf(strHour, "%" PRIu64 " %s", msg->transactionOut[i].hour, hourString);
 #else
-		sprintf(strHour, "%lu %s", msg->transactionOut[i].hour, hourString);
+		sprintf(strHour, "%" PRIu64 " %s", msg->transactionOut[i].hour, hourString);
 #endif
 
 		if (msg->transactionOut[i].has_address_index) {

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -313,33 +313,33 @@ void fsm_msgTransactionSign(TransactionSign* msg) {
 	for (uint32_t i = 0; i < msg->nbOut; ++i) {
 		char strHour[30];
 		char strCoin[30];
-    char strValue[20];
-		char* coinString = msg->transactionOut[i].coin == 1000000 ? _("coin") : _("coins");
-		char* hourString = (msg->transactionOut[i].hour == 1 || msg->transactionOut[i].hour == 0) ? _("hour") : _("hours");
-    char *strValueMsg = sprint_coin(msg->transactionOut[i].coin, SKYPARAM_DROPLET_PRECISION_EXP, sizeof(strValue), strValue);
-    if (strValueMsg == NULL) {
-      // FIXME: For Skycoin coin supply and precision buffer size should be enough
-      strCoin = "too many coins";
-    }
+		char strValue[20];
+		char *coinString = msg->transactionOut[i].coin == 1000000 ? _("coin") : _("coins");
+		char *hourString = (msg->transactionOut[i].hour == 1 || msg->transactionOut[i].hour == 0) ? _("hour") : _("hours");
+		char *strValueMsg = sprint_coins(msg->transactionOut[i].coin, SKYPARAM_DROPLET_PRECISION_EXP, sizeof(strValue), strValue);
+		if (strValueMsg == NULL) {
+			// FIXME: For Skycoin coin supply and precision buffer size should be enough
+			strcpy(strCoin, "too many coins");
+		}
 		sprintf(strCoin, "%s %s %s", _("send"), strValueMsg, coinString);
 		sprintf(strHour, "%" PRIu64 " %s", msg->transactionOut[i].hour, hourString);
 
 		if (msg->transactionOut[i].has_address_index) {
 			uint8_t pubkey[33] = {0};
-    		uint8_t seckey[32] = {0};
+			uint8_t seckey[32] = {0};
 			size_t size_address = 36;
 			char address[36] = {0};
-    		fsm_getKeyPairAtIndex(1, pubkey, seckey, NULL, msg->transactionOut[i].address_index);
+			fsm_getKeyPairAtIndex(1, pubkey, seckey, NULL, msg->transactionOut[i].address_index);
 			generate_base58_address_from_pubkey(pubkey, address, &size_address);
-		    if (strcmp(msg->transactionOut[i].address, address) != 0)
-		    {
-		        fsm_sendFailure(FailureType_Failure_AddressGeneration, _("Wrong return address"));
-		        #if EMULATOR
-		        printf("Internal address: %s, message address: %s\n", address, msg->transactionOut[i].address);
-		        printf("Comparaison size %ld\n", size_address);
-		        #endif
-		        return;
-		    }
+			if (strcmp(msg->transactionOut[i].address, address) != 0)
+			{
+					fsm_sendFailure(FailureType_Failure_AddressGeneration, _("Wrong return address"));
+					#if EMULATOR
+					printf("Internal address: %s, message address: %s\n", address, msg->transactionOut[i].address);
+					printf("Comparaison size %ld\n", size_address);
+					#endif
+					return;
+			}
 		} else {
 			layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Next"), NULL, _("Do you really want to"), strCoin, strHour, _("to address"), _("..."), NULL);
 			if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -45,6 +45,8 @@
 #include "skycoin_check_signature.h"
 #include "check_digest.h"
 #include "fsm_impl.h"
+#include "droplet.h"
+#include "skyparams.h"
 
 static uint8_t msg_resp[MSG_OUT_SIZE] __attribute__ ((aligned));
 
@@ -309,16 +311,18 @@ void fsm_msgTransactionSign(TransactionSign* msg) {
 		transaction_addInput(&transaction, hashIn);
 	}
 	for (uint32_t i = 0; i < msg->nbOut; ++i) {
-		char strHour[21];
-		char strCoin[21];
+		char strHour[30];
+		char strCoin[30];
+    char strValue[20];
 		char* coinString = msg->transactionOut[i].coin == 1000000 ? _("coin") : _("coins");
 		char* hourString = (msg->transactionOut[i].hour == 1 || msg->transactionOut[i].hour == 0) ? _("hour") : _("hours");
-		sprintf(strCoin, "%s %.2f %s",  _("send"), msg->transactionOut[i].coin / 1000000.00, coinString);
-#if EMULATOR
+    char *strValueMsg = sprint_coin(msg->transactionOut[i].coin, SKYPARAM_DROPLET_PRECISION_EXP, sizeof(strValue), strValue);
+    if (strValueMsg == NULL) {
+      // FIXME: For Skycoin coin supply and precision buffer size should be enough
+      strCoin = "too many coins";
+    }
+		sprintf(strCoin, "%s %s %s", _("send"), strValueMsg, coinString);
 		sprintf(strHour, "%" PRIu64 " %s", msg->transactionOut[i].hour, hourString);
-#else
-		sprintf(strHour, "%" PRIu64 " %s", msg->transactionOut[i].hour, hourString);
-#endif
 
 		if (msg->transactionOut[i].has_address_index) {
 			uint8_t pubkey[33] = {0};

--- a/tiny-firmware/firmware/skyparams.h
+++ b/tiny-firmware/firmware/skyparams.h
@@ -1,0 +1,8 @@
+
+#ifndef __SKYPARAMS_H__
+#define __SKYPARAMS_H__
+
+#define SKYPARAM_DROPLET_PRECISION     1000000
+#define SKYPARAM_DROPLET_PRECISION_EXP 6
+
+#endif

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -27,10 +27,11 @@ END_TEST
 START_TEST(test_droplet_small_buffer)
 {
   char msg[20];
-/*  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 3, msg));
-  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 4, msg));
-  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 5, msg)); */
-  ck_assert_str_eq("0.0001", sprint_coins(100, SKYPARAM_DROPLET_PRECISION_EXP, 6, msg));
+  ck_assert_ptr_null(sprint_coins(100, SKYPARAM_DROPLET_PRECISION_EXP, 3, msg));
+  ck_assert_ptr_null(sprint_coins(100, SKYPARAM_DROPLET_PRECISION_EXP, 4, msg));
+  ck_assert_ptr_null(sprint_coins(100, SKYPARAM_DROPLET_PRECISION_EXP, 5, msg));
+  ck_assert_ptr_null(sprint_coins(100, SKYPARAM_DROPLET_PRECISION_EXP, 6, msg));
+  ck_assert_str_eq("0.0001", sprint_coins(100, SKYPARAM_DROPLET_PRECISION_EXP, 7, msg));
 }
 END_TEST
 

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -18,14 +18,9 @@
 START_TEST(test_droplet_all_digits)
 {
   char msg[20];
-  uint64_t coins = 99999999999999;
-  ck_assert_str_eq("99999999.999999", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
-
-  coins = 10000000000001;
-  ck_assert_str_eq("10000000.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
-
-  coins = 2000001;
-  ck_assert_str_eq("2.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("99999999.999999", sprint_coins(99999999999999, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("10000000.000001", sprint_coins(10000000000001, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("2.000001", sprint_coins(2000001, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
 
@@ -43,19 +38,15 @@ END_TEST
 START_TEST(test_droplet_trim_fraction)
 {
   char msg[20];
-  uint64_t coins = 2010000;
-  ck_assert_str_eq("2.01", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("2.01", sprint_coins(2010000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
 
 START_TEST(test_droplet_trim_integer)
 {
   char msg[20];
-  uint64_t coins = 2000000;
-  ck_assert_str_eq("2", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
-
-  coins = 2001300000000;
-  ck_assert_str_eq("2001300", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("2", sprint_coins(2000000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("2001300", sprint_coins(2001300000000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
 

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -27,11 +27,10 @@ END_TEST
 START_TEST(test_droplet_small_buffer)
 {
   char msg[20];
-  uint64_t coins = 100;
-  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 3, msg));
+/*  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 3, msg));
   ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 4, msg));
-  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 5, msg));
-  ck_assert_str_eq("0.0001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 6, msg));
+  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 5, msg)); */
+  ck_assert_str_eq("0.0001", sprint_coins(100, SKYPARAM_DROPLET_PRECISION_EXP, 6, msg));
 }
 END_TEST
 
@@ -46,6 +45,8 @@ START_TEST(test_droplet_trim_integer)
 {
   char msg[20];
   ck_assert_str_eq("2", sprint_coins(2000000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("1", sprint_coins(1000000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("0", sprint_coins(0, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
   ck_assert_str_eq("2001300", sprint_coins(2001300000000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -11,8 +11,9 @@
 
 #include <check.h>
 
-#define "droplet.h"
-#define "skyparams.h"
+#include "test_droplet.h"
+#include "droplet.h"
+#include "skyparams.h"
 
 START_TEST(test_droplet_all_digits)
 {
@@ -57,4 +58,12 @@ START_TEST(test_droplet_trim_integer)
   ck_assert_str_eq("2001300", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
+
+TCase *add_droplet_tests(TCase *tc) {
+  tcase_add_test(tc, test_droplet_all_digits);
+  tcase_add_test(tc, test_droplet_small_buffer);
+  tcase_add_test(tc, test_droplet_trim_fraction);
+  tcase_add_test(tc, test_droplet_trim_integer);
+  return tc;
+}
 

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Skycoin project, https://skycoin.net/
+ *
+ * Copyright (C) 2018-2019 Skycoin Project
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include <check.h>
+
+#define "droplet.h"
+#define "skyparams.h"
+
+START_TEST(test_droplet_all_digits)
+{
+  char msg[20];
+  uint64_t coins = 99999999999999;
+  ck_assert_str_eq("99999999.999999", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+
+  coins = 10000000000001;
+  ck_assert_str_eq("100000000.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+}
+END_TEST
+
+START_TEST(test_droplet_buffer_underflow)
+{
+  char msg[20];
+  uint64_t coins = 100;
+  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 3, msg));
+  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 4, msg));
+  ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 5, msg));
+  ck_assert_str_eq("0.0001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 6, msg));
+}
+END_TEST
+

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -22,10 +22,13 @@ START_TEST(test_droplet_all_digits)
 
   coins = 10000000000001;
   ck_assert_str_eq("100000000.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+
+  coins = 2000001;
+  ck_assert_str_eq("2.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
 
-START_TEST(test_droplet_buffer_underflow)
+START_TEST(test_droplet_small_buffer)
 {
   char msg[20];
   uint64_t coins = 100;
@@ -33,6 +36,25 @@ START_TEST(test_droplet_buffer_underflow)
   ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 4, msg));
   ck_assert_ptr_null(sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 5, msg));
   ck_assert_str_eq("0.0001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 6, msg));
+}
+END_TEST
+
+START_TEST(test_droplet_trim_fraction)
+{
+  char msg[20];
+  uint64_t coins = 2010000;
+  ck_assert_str_eq("2.01", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+}
+END_TEST
+
+START_TEST(test_droplet_trim_integer)
+{
+  char msg[20];
+  uint64_t coins = 2000000;
+  ck_assert_str_eq("2", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+
+  coins = 2001300000000;
+  ck_assert_str_eq("2001300", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
 

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -22,7 +22,7 @@ START_TEST(test_droplet_all_digits)
   ck_assert_str_eq("99999999.999999", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 
   coins = 10000000000001;
-  ck_assert_str_eq("100000000.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("10000000.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 
   coins = 2000001;
   ck_assert_str_eq("2.000001", sprint_coins(coins, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));

--- a/tiny-firmware/firmware/test_droplet.h
+++ b/tiny-firmware/firmware/test_droplet.h
@@ -1,0 +1,15 @@
+/*
+ * This file is part of the Skycoin project, https://skycoin.net/
+ *
+ * Copyright (C) 2018-2019 Skycoin Project
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include <check.h>
+
+TCase *add_droplet_tests(TCase *tc);
+

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -142,6 +142,5 @@ TCase *add_fsm_tests(TCase *tc)
 	tcase_add_test(tc, test_msgGenerateMnemonicImplOk);
 	tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFaildIfItWasDone);
 	tcase_add_test(tc, test_msgSkycoinCheckMessageSignature);
-	suite_add_tcase(s, tc);
-	return s;
+	return tc;
 }

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -23,6 +23,8 @@
 #include "setup.h"
 #include "storage.h"
 
+#include "test_fsm.h"
+
 static uint8_t msg_resp[MSG_OUT_SIZE] __attribute__ ((aligned));
 
 #define setup_tc_fsm setup
@@ -132,11 +134,9 @@ START_TEST(test_msgSkycoinCheckMessageSignature)
 }
 END_TEST
 
-// define test suite and cases
-Suite *test_suite(void)
+// define test cases
+TCase *add_fsm_tests(TCase *tc)
 {
-	Suite *s = suite_create("firmware");
-	TCase *tc = tcase_create("fsm");
 	tcase_add_checked_fixture(tc, setup_tc_fsm, teardown_tc_fsm);
 	tcase_add_test(tc, test_msgSkycoinSignMessageReturnIsInHex);
 	tcase_add_test(tc, test_msgGenerateMnemonicImplOk);
@@ -144,19 +144,4 @@ Suite *test_suite(void)
 	tcase_add_test(tc, test_msgSkycoinCheckMessageSignature);
 	suite_add_tcase(s, tc);
 	return s;
-}
-
-// run suite
-int main(void)
-{
-	int number_failed;
-	Suite *s = test_suite();
-	SRunner *sr = srunner_create(s);
-	srunner_run_all(sr, CK_VERBOSE);
-	number_failed = srunner_ntests_failed(sr);
-	srunner_free(sr);
-	if (number_failed == 0) {
-		printf("PASSED ALL TESTS\n");
-	}
-	return number_failed;
 }

--- a/tiny-firmware/firmware/test_fsm.h
+++ b/tiny-firmware/firmware/test_fsm.h
@@ -1,0 +1,14 @@
+/*
+ * This file is part of the Skycoin project, https://skycoin.net/
+ *
+ * Copyright (C) 2018-2019 Skycoin Project
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include <check.h>
+
+TCase *add_fsm_tests(TCase *tc);

--- a/tiny-firmware/firmware/test_main.c
+++ b/tiny-firmware/firmware/test_main.c
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the Skycoin project, https://skycoin.net/
+ *
+ * Copyright (C) 2018-2019 Skycoin Project
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include <check.h>
+
+#include "test_droplet.h"
+#include "test_fsm.h"
+
+// define test suite and cases
+Suite *test_suite(void)
+{
+	Suite *s = suite_create("firmware");
+
+	suite_add_tcase(s, add_fsm_tests(tcase_create("fsm")));
+	suite_add_tcase(s, add_droplet_tests(tcase_create("droplet")));
+	return s;
+}
+
+// run suite
+int main(void)
+{
+	int number_failed;
+	Suite *s = test_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_VERBOSE);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+	if (number_failed == 0) {
+		printf("PASSED ALL TESTS\n");
+	}
+	return number_failed;
+}

--- a/tiny-firmware/protob/types.proto
+++ b/tiny-firmware/protob/types.proto
@@ -301,7 +301,7 @@ message SkycoinTransactionInput {
 
 message SkycoinTransactionOutput {
 	required string address = 1;
-	required uint32 coin = 2;
-	required uint32 hour = 3;
+	required uint64 coin = 2;
+	required uint64 hour = 3;
 	optional uint32 address_index = 4;
 }


### PR DESCRIPTION
Fixes #78
Fixes #91 

Changes:
- Change byte size of coins and hours `uint32_t` => `uint64_t`
- Function to render integer coin values as requested in #78 (no conversion to float)
- Include path properly set to run `make test` on osx and linux platforms

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
yes

Tested with check. Test code refactored to have a `main()` function and a separate mechanism to add test cases .

Related to skycoin/hardware-wallet-js#56 and skycoin/hardware-wallet-go#35
