### PR TITLE
fixes #79 - Support fot large txn

### DIFF
--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -273,8 +273,9 @@ void fsm_msgTransactionSign(TransactionSign* msg) {
 		if (strValueMsg == NULL) {
 			// FIXME: For Skycoin coin supply and precision buffer size should be enough
 			strcpy(strCoin, "too many coins");
+		} else {
+		  sprintf(strCoin, "%s %s %s", _("send"), strValueMsg, coinString);
 		}
-		sprintf(strCoin, "%s %s %s", _("send"), strValueMsg, coinString);
 		sprintf(strHour, "%" PRIu64 " %s", msg->transactionOut[i].hour, hourString);
 
 		if (msg->transactionOut[i].has_address_index) {


### PR DESCRIPTION
Fixes #79

Changes:
- Stream inputs and outputs for transactions with more than 8 inputs and/or 8 outputs

Message sequence :

1. Add an optional completion flag , semantics explained below
1. Completion flag not set for transactions with less than 8 inputs and 8 outputs. This case will be handled exactly same as before applying the changes.
1. Split all inputs into chunks of 8 items max.
1. If the number of inputs is over 8 then messages for all chunks (except the last one) will only contain inputs (i.e. empty outputs). Completion flag set to `false`
1. Split outputs into chunks of 8 items max.
1. The message containing the last inputs chunk is allowed to include the first outputs . Completion flag set to `true` if number of outputs is less than 8 .
1. If the number of outputs is over 8 then messages for other chunks will only contain outputs (i.e. empty inputs). The last chunk with outputs should set completion flag to `true`. Up to this point the wallet will compute inner hash internally
1. Resend (all) inputs (since transactions signed by hardware wallet in full). This is necessary due to the combination of two facts. On the one hand [inputs preceding outputs for inner hash](https://github.com/skycoin/skycoin/blob/develop/src/coin/transactions.go#L470-L476) . On the other hand , properties of crypto hashing functions do not allow for obtaining buffer hash from partial hashing values.

Any mismatch with respect to the above reported back as failure .

Does this change need to mentioned in CHANGELOG.md?
yes

Requires testing
yes

