### PR TITLE
[firmware] fixes #119 - Validate mnemonic count in firmware 

### DIFF
--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -45,8 +45,8 @@
 
 ErrCode_t msgGenerateMnemonicImpl(GenerateMnemonic* msg) {
  	CHECK_NOT_INITIALIZED_RET_ERR_CODE	    
-  if (msg->wordCount != 12 || msg->wordCount != 24) {
-		fsm_sendFailure(FailureType_Failure_ProcessDataError, _("Invalid number of words for mnemonic"));
+  if (msg->word_count != 12 && msg->word_count != 24) {
+		fsm_sendFailure(FailureType_Failure_DataError, _("Invalid number of words for mnemonic"));
 		return ErrFailed;
   }
 	int strength = (msg->word_count == 24)? MNEMONIC_STRENGTH_24 : MNEMONIC_STRENGTH_12 ;

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -45,6 +45,10 @@
 
 ErrCode_t msgGenerateMnemonicImpl(GenerateMnemonic* msg) {
  	CHECK_NOT_INITIALIZED_RET_ERR_CODE	    
+  if (msg->wordCount != 12 || msg->wordCount != 24) {
+		fsm_sendFailure(FailureType_Failure_ProcessDataError, _("Invalid number of words for mnemonic"));
+		return ErrFailed;
+  }
 	int strength = (msg->word_count == 24)? MNEMONIC_STRENGTH_24 : MNEMONIC_STRENGTH_12 ;
 	const char* mnemonic = mnemonic_generate(strength);
 	if (mnemonic == 0) {

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -57,11 +57,21 @@ START_TEST(test_msgGenerateMnemonicImplOk)
 }
 END_TEST
 
-START_TEST(test_msgGenerateMnemonicImplShouldFaildIfItWasDone)
+START_TEST(test_msgGenerateMnemonicImplShouldFailIfItWasDone)
 {
 	storage_wipe();
 	GenerateMnemonic msg = GenerateMnemonic_init_zero;
 	msgGenerateMnemonicImpl(&msg);
+	ErrCode_t ret = msgGenerateMnemonicImpl(&msg);
+	ck_assert_int_eq(ErrFailed, ret);
+}
+END_TEST
+
+START_TEST(test_msgGenerateMnemonicImplShouldFailForWrongSeedCount)
+{
+	storage_wipe();
+	GenerateMnemonic msg = GenerateMnemonic_init_zero;
+	msg.word_count = 17;
 	ErrCode_t ret = msgGenerateMnemonicImpl(&msg);
 	ck_assert_int_eq(ErrFailed, ret);
 }
@@ -188,7 +198,8 @@ TCase *add_fsm_tests(TCase *tc)
 	tcase_add_checked_fixture(tc, setup_tc_fsm, teardown_tc_fsm);
 	tcase_add_test(tc, test_msgSkycoinSignMessageReturnIsInHex);
 	tcase_add_test(tc, test_msgGenerateMnemonicImplOk);
-	tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFaildIfItWasDone);
+	tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFailIfItWasDone);
+	tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFailForWrongSeedCount);
 	tcase_add_test(tc, test_msgSkycoinCheckMessageSignature);
 	tcase_add_test(tc, test_msgApplySettingsLabelSuccess);
 	tcase_add_test(tc, test_msgFeaturesLabelDefaultsToDeviceId);


### PR DESCRIPTION

Fixes #119 

Changes:
- Check that word count in `GenerateMnemonic` message is either 12 or 24 . 

Known issues

Other valid values may be added later .

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
yes

Test case added in `test_fsm.c`.
