### PR TITLE
fixes #111 Print 1.5 coins correctly

### DIFF
--- a/tiny-firmware/firmware/droplet.c
+++ b/tiny-firmware/firmware/droplet.c
@@ -2,7 +2,7 @@
 #include "droplet.h"
 #include <stdio.h>
 
-char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
+char *sprint_coins(uint64_t coins, uint32_t precision_exp, size_t sz, char *msg) {
   uint64_t div, mod;
   char* eos = msg + sz;
   char* ptr = eos;
@@ -22,7 +22,7 @@ char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg) {
     mod = div % 10;
     div = div / 10;
   }
-  if (precision_exp > 0) {
+  if (precision_exp > 0 || mod > 0) {
     *ptr = '0' + mod;
     --ptr;
     if ((--sz) <= 0) {

--- a/tiny-firmware/firmware/droplet.h
+++ b/tiny-firmware/firmware/droplet.h
@@ -8,6 +8,6 @@
 /**
  * String representation of coins
  */
-char *sprint_coins(uint64_t coins, int precision_exp, size_t sz, char *msg);
+char *sprint_coins(uint64_t coins, uint32_t precision_exp, size_t sz, char *msg);
 
 #endif

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -39,10 +39,11 @@ START_TEST(test_droplet_trim_fraction)
 {
   char msg[20];
   ck_assert_str_eq("4.9023", sprint_coins(4902300, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
-  ck_assert_str_eq("9.503", sprint_coins(9503000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
-  ck_assert_str_eq("3.53", sprint_coins(3530000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("9.703", sprint_coins(9703000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("3.23", sprint_coins(3230000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
   ck_assert_str_eq("2.01", sprint_coins(2010000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
   ck_assert_str_eq("1.5", sprint_coins(1500000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("0.1", sprint_coins(100000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
 

--- a/tiny-firmware/firmware/test_droplet.c
+++ b/tiny-firmware/firmware/test_droplet.c
@@ -38,7 +38,11 @@ END_TEST
 START_TEST(test_droplet_trim_fraction)
 {
   char msg[20];
+  ck_assert_str_eq("4.9023", sprint_coins(4902300, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("9.503", sprint_coins(9503000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("3.53", sprint_coins(3530000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
   ck_assert_str_eq("2.01", sprint_coins(2010000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
+  ck_assert_str_eq("1.5", sprint_coins(1500000, SKYPARAM_DROPLET_PRECISION_EXP, 20, msg));
 }
 END_TEST
 


### PR DESCRIPTION
Fixes #111

Changes:
- Correct text when coins are 1.5
- Verify work for different fractions of coins

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
yes

Examples

4.9023 SKY = 4902300 droplets
9.703  SKY = 9703000 droplets
3.23  SKY = 3230000 droplets
2.01  SKY = 2010000 droplets
1.5  SKY = 1500000 droplets
0.1  SKY = 100000 droplets
