### PR TITLE
Delete label by accident ref #146

### DIFF
--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -252,13 +252,6 @@ void msgApplySettings(ApplySettings *msg)
 				_("No setting provided"));
 	if (msg->has_label) {
 		storage_setLabel(msg->label);
-	} else {
-		char label[DEVICE_LABEL_SIZE];
-		_Static_assert(sizeof(label) >= sizeof(storage_uuid_str), 
-						"Label can be truncated");
-		strncpy(label, storage_uuid_str, 
-				MIN(sizeof(storage_uuid_str), sizeof(label)));
-		storage_setLabel(label);
 	}
 	if (msg->has_language) {
 		storage_setLanguage(msg->language);

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -316,7 +316,27 @@ START_TEST(test_msgApplySettingsLabelSuccess)
     msg.has_label = true;
     strncpy(msg.label, raw_label, sizeof(msg.label));
     msgApplySettings(&msg);
-    ck_assert_int_eq(storage_hasLabel(), 1);
+    ck_assert_int_eq(storage_hasLabel(), true);
+    ck_assert_str_eq(storage_getLabel(), raw_label);
+}
+END_TEST
+
+START_TEST(test_msgApplySettingsLabelShouldNotBeRemovable)
+{
+    storage_wipe();
+    char raw_label[] = {
+        "my custom device label"};
+    ApplySettings msg = ApplySettings_init_zero;
+    msg.has_label = true;
+    strncpy(msg.label, raw_label, sizeof(msg.label));
+    msgApplySettings(&msg);
+    ck_assert_int_eq(storage_hasLabel(), true);
+    ck_assert_str_eq(storage_getLabel(), raw_label);
+    msg.has_label = false;
+    memset(msg.label, 0, sizeof(msg.label));
+    msg.has_use_passphrase = true;
+    msg.use_passphrase = true;
+    msgApplySettings(&msg);
     ck_assert_str_eq(storage_getLabel(), raw_label);
 }
 END_TEST
@@ -373,6 +393,7 @@ TCase *add_fsm_tests(TCase *tc)
 	tcase_add_test(tc, test_msgFeaturesLabelDefaultsToDeviceId);
 	tcase_add_test(tc, test_msgGetFeatures);
 	tcase_add_test(tc, test_msgApplySettingsLabelSuccessCheck);
+    tcase_add_test(tc, test_msgApplySettingsLabelShouldNotBeRemovable);
 	tcase_add_test(tc, test_msgFeaturesLabelDefaultsToDeviceId);
 	tcase_add_test(
 		tc, 

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -327,9 +327,12 @@ START_TEST(test_msgApplySettingsLabelShouldNotBeRemovable)
     char raw_label[] = {
         "my custom device label"};
     ApplySettings msg = ApplySettings_init_zero;
+    msg.has_use_passphrase = true;
+    msg.use_passphrase = false;
     msg.has_label = true;
     strncpy(msg.label, raw_label, sizeof(msg.label));
     msgApplySettings(&msg);
+    ck_assert(!storage_hasPassphraseProtection());
     ck_assert_int_eq(storage_hasLabel(), true);
     ck_assert_str_eq(storage_getLabel(), raw_label);
     msg.has_label = false;
@@ -338,6 +341,7 @@ START_TEST(test_msgApplySettingsLabelShouldNotBeRemovable)
     msg.use_passphrase = true;
     msgApplySettings(&msg);
     ck_assert_str_eq(storage_getLabel(), raw_label);
+    ck_assert(storage_hasPassphraseProtection());
 }
 END_TEST
 
@@ -393,7 +397,7 @@ TCase *add_fsm_tests(TCase *tc)
 	tcase_add_test(tc, test_msgFeaturesLabelDefaultsToDeviceId);
 	tcase_add_test(tc, test_msgGetFeatures);
 	tcase_add_test(tc, test_msgApplySettingsLabelSuccessCheck);
-    tcase_add_test(tc, test_msgApplySettingsLabelShouldNotBeRemovable);
+	tcase_add_test(tc, test_msgApplySettingsLabelShouldNotBeRemovable);
 	tcase_add_test(tc, test_msgFeaturesLabelDefaultsToDeviceId);
 	tcase_add_test(
 		tc, 


### PR DESCRIPTION
Fixes #146

Changes:
- Do not delete(restore to a default value) label if it is not have a value in applySettings.

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
yes
