### PR TITLE
Fixes #151  Validate input data 

### DIFF
--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -392,7 +392,7 @@ void fsm_msgPing(Ping *msg)
 	}
 
 	if (msg->has_message) {
-		if (msg->message == NULL)
+		if (msg->message == "")
 		{
 			fsm_sendFailure(FailureType_Failure_DataError, "Message in empty");
 			return;

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -370,8 +370,8 @@ void fsm_msgSkycoinAddress(SkycoinAddress* msg)
 void fsm_msgPing(Ping *msg)
 {
 	RESP_INIT(Success);
-
-	if (msg->has_button_protection && msg->button_protection) {
+	
+		if (msg->has_button_protection && msg->button_protection) {
 		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("answer to ping?"), NULL, NULL, NULL, NULL);
 		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
 			fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
@@ -392,6 +392,11 @@ void fsm_msgPing(Ping *msg)
 	}
 
 	if (msg->has_message) {
+		if (msg->message == NULL)
+		{
+			fsm_sendFailure(FailureType_Failure_DataError, "Message in empty");
+			return;
+		}
 		resp->has_message = true;
 		memcpy(&(resp->message), &(msg->message), sizeof(resp->message));
 	}

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -392,7 +392,7 @@ void fsm_msgPing(Ping *msg)
 	}
 
 	if (msg->has_message) {
-		if (msg->message == "")
+		if (strcmp(msg->message,"")==0)
 		{
 			fsm_sendFailure(FailureType_Failure_DataError, "Message in empty");
 			return;

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -188,7 +188,7 @@ ErrCode_t msgSkycoinAddress(SkycoinAddress* msg, ResponseSkycoinAddress *resp)
 		fsm_sendFailure(FailureType_Failure_AddressGeneration, "Key pair generation failed");
 		return ErrFailed;
 	}
-	if (msg->address_n == 1 && msg->has_confirm_address && (bool)msg->confirm_address) {
+	if (msg->address_n == 1 && (bool)msg->has_confirm_address && (bool)msg->confirm_address) {
 		char * addr = resp->addresses[0];
 		layoutAddress(addr);
 		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -261,9 +261,9 @@ void msgApplySettings(ApplySettings *msg)
 	_Static_assert(
 		sizeof(msg->label) == DEVICE_LABEL_SIZE, 
 		"device label size inconsitent betwen protocol and final storage");
-	CHECK_PARAM(msg->has_label || msg->has_language || msg->has_use_passphrase || msg->has_homescreen,
-				_("No setting provided"));
-	
+	CHECK_PARAM(msg->has_label || msg->has_use_passphrase || msg->has_homescreen,
+							_("No setting provided"));
+
 	if (msg->has_label) {
 		storage_setLabel(msg->label);
 	} else {
@@ -276,6 +276,8 @@ void msgApplySettings(ApplySettings *msg)
 	}
 	if (msg->has_language) {
 		storage_setLanguage(msg->language);
+	}else{
+		storage_setLanguage(DEFAULT_LANGUAGE);
 	}
 	if (msg->has_use_passphrase) {
 		storage_setPassphraseProtection((bool)msg->use_passphrase);

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -79,16 +79,18 @@ ErrCode_t msgGenerateMnemonicImpl(
 		void (*random_buffer_func)(uint8_t *buf, size_t len)) {
 	CHECK_NOT_INITIALIZED_RET_ERR_CODE
 	strength = MNEMONIC_STRENGTH_12;
-	if (msg->has_word_count) {
-		switch (msg->word_count) {
-			case MNEMONIC_WORD_COUNT_12:
-				strength = MNEMONIC_STRENGTH_12;
-				break;
-			case MNEMONIC_WORD_COUNT_24:
-				strength = MNEMONIC_STRENGTH_24;
-				break;
-			default:
-				return ErrInvalidArg;
+	if (msg->has_word_count)
+	{
+		switch (msg->word_count)
+		{
+		case MNEMONIC_WORD_COUNT_12:
+			strength = MNEMONIC_STRENGTH_12;
+			break;
+		case MNEMONIC_WORD_COUNT_24:
+			strength = MNEMONIC_STRENGTH_24;
+			break;
+		default:
+			return ErrInvalidArg;
 		}
 	}
 	random_buffer_func(int_entropy, sizeof(int_entropy));
@@ -96,7 +98,7 @@ ErrCode_t msgGenerateMnemonicImpl(
 		awaiting_entropy = true;
 		if (msg->has_passphrase_protection) {
 			has_passphrase_protection = msg->has_passphrase_protection;
-			passphrase_protection = msg->passphrase_protection;
+			passphrase_protection = (bool)msg->passphrase_protection;
 		}
 		return ErrLowEntropy;
 	}
@@ -106,7 +108,7 @@ ErrCode_t msgGenerateMnemonicImpl(
 		storage_setNeedsBackup(true);
 		storage_setPassphraseProtection(
 					msg->has_passphrase_protection
-					&& msg->passphrase_protection);
+					&& (bool)msg->passphrase_protection);
 		memset(int_entropy, 0, sizeof(int_entropy));
 		storage_update();
 		return ErrOk;
@@ -252,7 +254,6 @@ void msgApplySettings(ApplySettings *msg)
 	CHECK_PARAM(msg->has_label || msg->has_language || msg->has_use_passphrase || msg->has_homescreen,
 				_("No setting provided"));
 	
-	CHECK_PARAM(msg->use_passphrase == true || msg->use_passphrase==false,_("No use_passphrase is bool"));
 	if (msg->has_label) {
 		storage_setLabel(msg->label);
 	} else {
@@ -267,7 +268,7 @@ void msgApplySettings(ApplySettings *msg)
 		storage_setLanguage(msg->language);
 	}
 	if (msg->has_use_passphrase) {
-		storage_setPassphraseProtection(msg->use_passphrase);
+		storage_setPassphraseProtection((bool)msg->use_passphrase);
 	}
 	if (msg->has_homescreen) {
 		storage_setHomescreen(msg->homescreen.bytes, msg->homescreen.size);

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -79,18 +79,16 @@ ErrCode_t msgGenerateMnemonicImpl(
 		void (*random_buffer_func)(uint8_t *buf, size_t len)) {
 	CHECK_NOT_INITIALIZED_RET_ERR_CODE
 	strength = MNEMONIC_STRENGTH_12;
-	if (msg->has_word_count)
-	{
-		switch (msg->word_count)
-		{
-		case MNEMONIC_WORD_COUNT_12:
-			strength = MNEMONIC_STRENGTH_12;
-			break;
-		case MNEMONIC_WORD_COUNT_24:
-			strength = MNEMONIC_STRENGTH_24;
-			break;
-		default:
-			return ErrInvalidArg;
+	if (msg->has_word_count) {
+		switch (msg->word_count) {
+			case MNEMONIC_WORD_COUNT_12:
+				strength = MNEMONIC_STRENGTH_12;
+				break;
+			case MNEMONIC_WORD_COUNT_24:
+				strength = MNEMONIC_STRENGTH_24;
+				break;
+			default:
+				return ErrInvalidArg;
 		}
 	}
 	random_buffer_func(int_entropy, sizeof(int_entropy));
@@ -117,8 +115,7 @@ ErrCode_t msgGenerateMnemonicImpl(
 }
 
 
-void msgSkycoinSignMessageImpl(SkycoinSignMessage* msg,
-								   ResponseSkycoinSignMessage *resp)
+void msgSkycoinSignMessageImpl(SkycoinSignMessage* msg, ResponseSkycoinSignMessage *resp)
 {
 	_Static_assert(131 == sizeof(msg->message),
 				   "Message size does not match.");
@@ -205,24 +202,20 @@ ErrCode_t msgSkycoinCheckMessageSignatureImpl(
 		Success *successResp,
 		Failure *failureResp) {
 
-	_Static_assert(66 == sizeof(msg->message),
-				   "Message size does not match.");
-    _Static_assert(37 == sizeof(msg->address),
-                       "Address size does not match.");
-	_Static_assert(131 == sizeof(msg->signature),
-				   "Signature size does not match.");
+	_Static_assert(66 == sizeof(msg->message), "Message size does not match.");
+	_Static_assert(37 == sizeof(msg->address), "Address size does not match.");
+	_Static_assert(131 == sizeof(msg->signature), "Signature size does not match.");
 	// NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
-    // /2 because the hex to buff conversion.
-    uint8_t sign[(sizeof(msg->signature) - 1) / 2];
-    // NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
-    char pubkeybase58[sizeof(msg->address)] = {0};
-    uint8_t pubkey[33] = {0};
-    // NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
-    // /2 because the hex to buff conversion.
-    uint8_t digest[(sizeof(msg->message) - 1) / 2] = {0};
-    if (is_digest(msg->message) == false) {
-      compute_sha256sum((const uint8_t *)msg->message, digest,
-                        strlen(msg->message));
+	// /2 because the hex to buff conversion.
+	uint8_t sign[(sizeof(msg->signature) - 1) / 2];
+	// NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
+	char pubkeybase58[sizeof(msg->address)] = {0};
+	uint8_t pubkey[33] = {0};
+	// NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
+	// /2 because the hex to buff conversion.
+	uint8_t digest[(sizeof(msg->message) - 1) / 2] = {0};
+	if (is_digest(msg->message) == false) {
+		compute_sha256sum((const uint8_t *)msg->message, digest, strlen(msg->message));
 	} else {
 		tobuff(msg->message, digest, MIN(sizeof(digest), sizeof(msg->message)));
 	}
@@ -261,16 +254,13 @@ void msgApplySettings(ApplySettings *msg)
 	_Static_assert(
 		sizeof(msg->label) == DEVICE_LABEL_SIZE, 
 		"device label size inconsitent betwen protocol and final storage");
-	CHECK_PARAM(msg->has_label || msg->has_use_passphrase || msg->has_homescreen,
-							_("No setting provided"));
+	CHECK_PARAM(msg->has_label || msg->has_use_passphrase || msg->has_homescreen, _("No setting provided"));
 
 	if (msg->has_label) {
 		storage_setLabel(msg->label);
 	}
 	if (msg->has_language) {
 		storage_setLanguage(msg->language);
-	}else{
-		storage_setLanguage(DEFAULT_LANGUAGE);
 	}
 	if (msg->has_use_passphrase) {
 		storage_setPassphraseProtection((bool)msg->use_passphrase);

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -245,11 +245,14 @@ ErrCode_t msgSkycoinCheckMessageSignatureImpl(
 
 void msgApplySettings(ApplySettings *msg)
 {
+	
 	_Static_assert(
 		sizeof(msg->label) == DEVICE_LABEL_SIZE, 
 		"device label size inconsitent betwen protocol and final storage");
 	CHECK_PARAM(msg->has_label || msg->has_language || msg->has_use_passphrase || msg->has_homescreen,
 				_("No setting provided"));
+	
+	CHECK_PARAM(msg->use_passphrase == true || msg->use_passphrase==false,_("No use_passphrase is bool"));
 	if (msg->has_label) {
 		storage_setLabel(msg->label);
 	} else {

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -18,6 +18,7 @@
 #define EXTERNAL_ENTROPY_MAX_SIZE 128
 #define MNEMONIC_WORD_COUNT_12 12
 #define MNEMONIC_WORD_COUNT_24 24
+#define DEFAULT_LANGUAGE "english"
 
 // message methods
 

--- a/tiny-firmware/firmware/storage.c
+++ b/tiny-firmware/firmware/storage.c
@@ -440,10 +440,12 @@ void storage_setLanguage(const char *lang)
 {
 	if (!lang) return;
 	// sanity check
-	if (strcmp(lang, "english") == 0) {
-		storageUpdate.has_language = true;
+	storageUpdate.has_language = true;
+	if (strcmp(lang, "english") == 0){
 		strlcpy(storageUpdate.language, lang, sizeof(storageUpdate.language));
-	}
+	}else{
+          strlcpy(storageUpdate.language, "english", sizeof(storageUpdate.language));
+    }
 }
 
 void storage_setPassphraseProtection(bool passphrase_protection)

--- a/tiny-firmware/firmware/storage.c
+++ b/tiny-firmware/firmware/storage.c
@@ -440,12 +440,10 @@ void storage_setLanguage(const char *lang)
 {
 	if (!lang) return;
 	// sanity check
-	storageUpdate.has_language = true;
 	if (strcmp(lang, "english") == 0){
+		storageUpdate.has_language = true;
 		strlcpy(storageUpdate.language, lang, sizeof(storageUpdate.language));
-	}else{
-          strlcpy(storageUpdate.language, "english", sizeof(storageUpdate.language));
-    }
+	}
 }
 
 void storage_setPassphraseProtection(bool passphrase_protection)

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -354,6 +354,20 @@ START_TEST(test_msgGetFeatures)
 }
 END_TEST
 
+START_TEST(test_msgApplySettingsValidateParameter)
+{
+    storage_wipe();
+    char raw_label[] = {
+        "my custom device label"};
+    ApplySettings msg = ApplySettings_init_zero;
+    msg.use_passphrase = NULL;
+    strncpy(msg.label, raw_label, sizeof(msg.label));
+    msgApplySettings(&msg);
+    ck_assert_int_eq(storage_hasLabel(), true);
+    ck_assert(sizeof(msg.use_passphrase)== sizeof(bool));
+}
+END_TEST
+
 // define test cases
 TCase *add_fsm_tests(TCase *tc)
 {
@@ -378,5 +392,6 @@ TCase *add_fsm_tests(TCase *tc)
 		tc, 
 		test_msgEntropyAckImplFailAsExpectedForSyncProblemInProtocol);
 	tcase_add_test(tc, test_msgGenerateMnemonicEntropyAckSequenceShouldBeOk);
-	return tc;
+    tcase_add_test(tc, test_msgApplySettingsValidateParameter);
+    return tc;
 }

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -360,12 +360,53 @@ START_TEST(test_msgApplySettingsValidateParameter)
     storage_wipe();
     char raw_label[] = {
         "my custom device label"};
+    // Validate has_label is false
     ApplySettings msg = ApplySettings_init_zero;
-    msg.use_passphrase = NULL;
     strncpy(msg.label, raw_label, sizeof(msg.label));
+    msg.has_label = false;
     msgApplySettings(&msg);
     ck_assert_int_eq(storage_hasLabel(), true);
+    ck_assert_str_ne(storage_getLabel(),raw_label);
+
+    //msg.has_label is true
+    strncpy(msg.label, raw_label, sizeof(msg.label));
+    msg.has_label = true;
+    msgApplySettings(&msg);
+    ck_assert_int_eq(storage_hasLabel(), true);
+    ck_assert_str_eq(storage_getLabel(), raw_label);
+
+    //msg.has_language value default
+
+    // has_language == false
+    ck_assert_int_eq(msg.has_language, false);
+    ck_assert_str_eq(msg.language, "");
+
+    // has_language is true
+    msg.has_language = true;
+    strcpy(msg.language, "english");
+    msgApplySettings(&msg);
+    ck_assert_str_eq(storage_getLanguage(), "english");
+
+    // Validate use_passphrase is NULL or false
+    msg.use_passphrase = NULL;
+    msgApplySettings(&msg);
     ck_assert(!storage_hasPassphraseProtection());
+
+    msg.use_passphrase = false;
+    msgApplySettings(&msg);
+    ck_assert(!storage_hasPassphraseProtection());
+
+    // Validate use_passphrase is false and has_use_passphrase is true
+    msg.use_passphrase = false;
+    msg.has_use_passphrase = true;
+    msgApplySettings(&msg);
+    ck_assert(!storage_hasPassphraseProtection());
+
+    // Validate use_passphrase is true
+    msg.use_passphrase = true;
+    msg.has_use_passphrase = true;
+    msgApplySettings(&msg);
+    ck_assert(storage_hasPassphraseProtection());
 }
 END_TEST
 

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -364,7 +364,16 @@ START_TEST(test_msgApplySettingsValidateParameter)
     strncpy(msg.label, raw_label, sizeof(msg.label));
     msgApplySettings(&msg);
     ck_assert_int_eq(storage_hasLabel(), true);
-    ck_assert(sizeof(msg.use_passphrase)== sizeof(bool));
+    ck_assert(!storage_hasPassphraseProtection());
+}
+END_TEST
+
+START_TEST(test_msgGenerateMnemonicImplCheckParameter)
+{
+    storage_wipe();
+    GenerateMnemonic msg = {true, NULL, 0, 12};
+    ErrCode_t ret = msgGenerateMnemonicImpl(&msg, &random_buffer);
+    ck_assert_int_eq(ErrOk, ret);
 }
 END_TEST
 
@@ -393,5 +402,6 @@ TCase *add_fsm_tests(TCase *tc)
 		test_msgEntropyAckImplFailAsExpectedForSyncProblemInProtocol);
 	tcase_add_test(tc, test_msgGenerateMnemonicEntropyAckSequenceShouldBeOk);
     tcase_add_test(tc, test_msgApplySettingsValidateParameter);
+    tcase_add_test(tc, test_msgGenerateMnemonicImplCheckParameter);
     return tc;
 }

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -443,6 +443,55 @@ START_TEST(test_msgGenerateMnemonicImplCheckParameter)
 }
 END_TEST
 
+START_TEST(test_msgSkycoinAddressCheckParameter)
+{
+  // Only send address_n
+  RESP_INIT(ResponseSkycoinAddress)
+  storage_wipe();
+  SkycoinAddress msg;
+  msg.address_n = 10;
+  ErrCode_t err = msgSkycoinAddress(&msg, resp);
+  ck_assert_int_eq(err, ErrFailed);
+
+  // Only send confirm_address
+  storage_wipe();
+  memset(&msg, 0, sizeof(SkycoinAddress));
+  memset(resp, 0, sizeof(ResponseSkycoinAddress));
+  msg.confirm_address = true;
+  err = msgSkycoinAddress(&msg, resp);
+  ck_assert_int_eq(err, ErrFailed);
+
+  // Only send start_index
+  storage_wipe();
+  memset(&msg, 0, sizeof(SkycoinAddress));
+  memset(resp, 0, sizeof(ResponseSkycoinAddress));
+  msg.start_index = 0;
+  err = msgSkycoinAddress(&msg, resp);
+  ck_assert_int_eq(err, ErrFailed);
+
+  // Send start_index and address_n
+  storage_wipe();
+  memset(&msg, 0, sizeof(SkycoinAddress));
+  memset(resp, 0, sizeof(ResponseSkycoinAddress));
+  msg.start_index = 0;
+  msg.address_n = 2;
+  err = msgSkycoinAddress(&msg, resp);
+  ck_assert_int_eq(err, ErrFailed);
+
+  // Send start_index , address_n  && confirm_address
+  storage_wipe();
+  forceGenerateMnemonic();
+  memset(&msg, 0, sizeof(SkycoinAddress));
+  memset(resp, 0, sizeof(ResponseSkycoinAddress));
+  msg.start_index = 0;
+  msg.address_n = 2;
+  msg.confirm_address = false;
+  err = msgSkycoinAddress(&msg, resp);
+  ck_assert_int_eq(err, ErrOk);
+  ck_assert_int_eq(msg.address_n,resp->addresses_count);
+}
+END_TEST
+
 // define test cases
 TCase *add_fsm_tests(TCase *tc)
 {
@@ -470,5 +519,6 @@ TCase *add_fsm_tests(TCase *tc)
 	tcase_add_test(tc, test_msgGenerateMnemonicEntropyAckSequenceShouldBeOk);
     tcase_add_test(tc, test_msgApplySettingsValidateParameter);
     tcase_add_test(tc, test_msgGenerateMnemonicImplCheckParameter);
+    tcase_add_test(tc, test_msgSkycoinAddressCheckParameter);
     return tc;
 }

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -264,6 +264,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage
     forceGenerateMnemonic();
     SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
     msgSkyAddress.address_n = 1;
+    msgSkyAddress.confirm_address = NULL;
     uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
     ResponseSkycoinAddress *respAddress = 
             (ResponseSkycoinAddress *) (void *) msg_resp_addr;


### PR DESCRIPTION
Fixes #151 

Changes:
- Changes in the functions of control and validating the parameters of inputs of the structures to eliminate errors when entering the data the clients
- Defining when the data type `bool` the client sends it as `NULL`, which captures it as `false`.
-  Added test to `msgSkycoinAddress` and `msgApplySettings`
-  Validate  the message not null in `msgPing`

Does this change need to mentioned in CHANGELOG.md?
 no

Requires testing
yes

