### PR TITLE
fixes #142 Refactor fsm.c for unit testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ script:
   - make -C tiny-firmware/protob install-deps-nanopb
   - make -C tiny-firmware/protob install-protoc
   - make -C tiny-firmware/protob/nanopb/vendor/nanopb/generator/proto
-  - make -C skycoin-api test
-  - make -C skycoin-api clean
+  - make test
+  - make clean
   - find tiny-firmware/protob/nanopb/vendor/nanopb
   - make emulator
   - make clean

--- a/tiny-firmware/firmware/error.h
+++ b/tiny-firmware/firmware/error.h
@@ -18,13 +18,14 @@
  * @brief The ErrMode enum represents the error modes.
  */
 enum ErrMode {
-	ReasonSuccess = 0, /*!< Success */
-	ReasonUnknown = 0xFFF, /*!< Reason unknown */
-	ReasonArgumentError = 1, /*!< Unexpected or invalid argument */
-	ReasonOutOfBounds = 2, /*!< Value out of bounds */
-	ReasonInvalidState = 3, /*!< The system get in an invalid state, for example a syc problem in server implementation */
-	ReasonNotUefulResult = 4, /*!< The result value is not useful */
-	ReasonValueError = 5, /*!< Unexpected or invalid value */
+	ReasonSuccess = 0,		/*!< Success */
+	ReasonUnknown = 0xFFF,		/*!< Reason unknown */
+	ReasonArgumentError = 1,	/*!< Unexpected or invalid argument */
+	ReasonOutOfBounds = 2,		/*!< Value out of bounds */
+	ReasonInvalidState = 3,		/*!< The system get in an invalid state, for example a syc problem in server implementation */
+	ReasonValueError = 4,		/*!< Unexpected or invalid value */
+	ReasonNotImplemented = 5,	/*!< Not implemented code */
+	ReasonActionCancelled = 6, /*!< Action cancelled by user*/
 };
 
 // 32-bits error constants are structured as folows:
@@ -38,9 +39,15 @@ enum ErrMode {
  * @brief The ErrCategory enum
  */
 enum ErrCategory {
-	PkgGeneric = 0, /*!< Byte prefix for generic error codes */
-	PkgEntropy = 1, /*!< Byte prefix for entropy error codes */
-	PkgServer = 2, /*! < Server schema related errors */
+  PkgGeneric = 1, /*! < Generic error codes */
+	PkgEntropy = 2, /*! < Entropy error codes */
+	PkgServer = 3, /*!  < Server schema related errors */
+	PkgSign = 4, /*!    < Signing errors */
+	PkgPinChk = 5, /*!  < Pin errors */
+	PkgStorage = 6, /*! < Storage errors */
+	PkgMnemonic = 7, /*!< Mnemonic errors */
+	PkgAddress = 8, /*! < Address errors */
+	PkgBackup = 9, /*!  < Backup errors */
 } __attribute__ ((__packed__));
 _Static_assert(sizeof (enum ErrCategory) == 1, "One byte as max for package");
 
@@ -48,13 +55,25 @@ _Static_assert(sizeof (enum ErrCategory) == 1, "One byte as max for package");
  * @brief The ErrCode enum
  */
 enum ErrCode {
-	ErrOk =						ERROR_CODE(PkgGeneric, ReasonSuccess),  /*!< Operation completed successfully */
-	ErrFailed =					ERROR_CODE(PkgGeneric, ReasonUnknown),  /*!< Generic failure */
-	ErrInvalidArg =				ERROR_CODE(PkgGeneric, ReasonArgumentError),  /*!< Invalid argument */
-	ErrIndexValue =				ERROR_CODE(PkgGeneric, ReasonOutOfBounds),  /*!< Index out of bounds */
-	ErrInvalidValue =			ERROR_CODE(PkgGeneric, ReasonValueError),  /*!< Invalid value */
-	ErrLowEntropy =				ERROR_CODE(PkgEntropy, ReasonArgumentError),  /*!< Buffer entropy under 4.0 bits/symbol */
-	ErrUnexpectedMessage =		ERROR_CODE(PkgServer, ReasonInvalidState),  /*! < Server state loses path */
+	ErrOk = ERROR_CODE(PkgGeneric, ReasonSuccess),			     /*!< Operation completed successfully */
+	ErrFailed = ERROR_CODE(PkgGeneric, ReasonUnknown),		     /*!< Generic failure */
+	ErrInvalidArg = ERROR_CODE(PkgGeneric, ReasonArgumentError),	     /*!< Invalid argument */
+	ErrIndexValue = ERROR_CODE(PkgGeneric, ReasonOutOfBounds),	     /*!< Index out of bounds */
+	ErrInvalidValue = ERROR_CODE(PkgGeneric, ReasonValueError),	     /*!< Invalid value */
+	ErrNotImplemented = ERROR_CODE(PkgGeneric, ReasonNotImplemented),    /*!< Feature not implemented */
+	ErrPinRequired = ERROR_CODE(PkgPinChk, ReasonInvalidState),          /*!< Action requires PIN and is not configured */
+	ErrPinMismatch = ERROR_CODE(PkgPinChk, ReasonValueError),          /*!< Action requires PIN and it didn't match */
+	ErrPinCancelled = ERROR_CODE(PkgPinChk, ReasonActionCancelled), /*!< Action requires PIN and was cancelled by user */
+	ErrActionCancelled = ERROR_CODE(PkgGeneric, ReasonActionCancelled), /*!< Action cancelled by user */
+	ErrNotInitialized = ERROR_CODE(PkgStorage, ReasonInvalidState), /*!< Storage not initialized */
+	ErrMnemonicRequired = ERROR_CODE(PkgMnemonic, ReasonInvalidState), /*!< Mnemonic required */
+	ErrAddressGeneration = ERROR_CODE(PkgAddress, ErrInvalidValue), /*!< Failed address generation */
+	ErrTooManyAddresses = ERROR_CODE(PkgAddress, ReasonOutOfBounds), /*!< Too many addresses to generate */
+	ErrUnfinishedBackup = ERROR_CODE(PkgBackup, ReasonInvalidState), /*!< Backup operation did not finish properly */
+	ErrLowEntropy = ERROR_CODE(PkgEntropy, ReasonArgumentError),	     /*!< Buffer entropy under 4.0 bits/symbol */
+	ErrUnexpectedMessage = ERROR_CODE(PkgServer, ReasonInvalidState),    /*!< Server state loses path */
+	ErrSignPreconditionFailed = ERROR_CODE(PkgSign, ReasonInvalidState), /*!< Signing precondition failed */
+	ErrInvalidSignature = ERROR_CODE(PkgSign, ReasonValueError), /*!< Invalid Message Signature */
 };
 typedef enum ErrCode ErrCode_t;
 _Static_assert(sizeof (ErrCode_t) == 4, "One byte as max for package");

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -272,7 +272,7 @@ void fsm_msgApplySettings(ApplySettings *msg)
 			return;
 		}
 	}
-	msgApplySettings(msg);
+	msgApplySettingsImpl(msg);
 	fsm_sendSuccess(_("Settings applied"));
 	layoutHome();
 }
@@ -451,7 +451,7 @@ void fsm_msgSkycoinSignMessage(SkycoinSignMessage *msg)
 void fsm_msgSkycoinAddress(SkycoinAddress* msg)
 {
 	RESP_INIT(ResponseSkycoinAddress);
-	if (msgSkycoinAddress(msg, resp) == ErrOk) {
+	if (msgSkycoinAddressImpl(msg, resp) == ErrOk) {
 		msg_write(MessageType_MessageType_ResponseSkycoinAddress, resp);
 	}
 	layoutHome();

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -236,36 +236,9 @@ void fsm_msgInitialize(Initialize *msg)
 void fsm_msgApplySettings(ApplySettings *msg)
 {
 	CHECK_PIN
-	if (msg->has_label && strlen(msg->label)) {
+	msg->has_label = msg->has_label && strlen(msg->label);
+	if (msg->has_label) {
 		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("change name to"), msg->label, "?", NULL, NULL);
-		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
-			fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
-			layoutHome();
-			return;
-		}
-	} else {
-		msg->has_label = false;
-	}
-	if (msg->has_language && strlen(msg->language)) {
-		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("change language to"), msg->language, "?", NULL, NULL);
-		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
-			fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
-			layoutHome();
-			return;
-		}
-	} else {
-		msg->has_language = false;
-	}
-	if (msg->has_use_passphrase) {
-		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), msg->use_passphrase ? _("enable passphrase") : _("disable passphrase"), _("protection?"), NULL, NULL, NULL);
-		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
-			fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
-			layoutHome();
-			return;
-		}
-	}
-	if (msg->has_homescreen) {
-		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("change the home"), _("screen?"), NULL, NULL, NULL);
 		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
 			fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
 			layoutHome();

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -451,8 +451,11 @@ void fsm_msgSkycoinSignMessage(SkycoinSignMessage *msg)
 void fsm_msgSkycoinAddress(SkycoinAddress* msg)
 {
 	RESP_INIT(ResponseSkycoinAddress);
-	if (msgSkycoinAddressImpl(msg, resp) == ErrOk) {
+	ErrCode_t err = msgSkycoinAddressImpl(msg, resp);
+	if (err == ErrOk) {
 		msg_write(MessageType_MessageType_ResponseSkycoinAddress, resp);
+	} else {
+		fsm_sendResponseFromErrCode(err, NULL, NULL);
 	}
 	layoutHome();
 }

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -163,7 +163,7 @@ ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index,
 	return res;
 }
 
-ErrCode_t msgSkycoinAddress(SkycoinAddress* msg, ResponseSkycoinAddress *resp)
+ErrCode_t msgSkycoinAddressImpl(SkycoinAddress* msg, ResponseSkycoinAddress *resp)
 {
 	uint8_t seckey[32] = {0};
 	uint8_t pubkey[33] = {0};
@@ -243,7 +243,7 @@ ErrCode_t msgSkycoinCheckMessageSignatureImpl(
 	return ret;
 }
 
-void msgApplySettings(ApplySettings *msg)
+void msgApplySettingsImpl(ApplySettings *msg)
 {
 	_Static_assert(
 		sizeof(msg->label) == DEVICE_LABEL_SIZE, 

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -245,6 +245,19 @@ ErrCode_t msgApplySettingsImpl(ApplySettings *msg) {
 		sizeof(msg->label) == DEVICE_LABEL_SIZE, 
 		"device label size inconsitent betwen protocol and final storage");
 	CHECK_PARAM_RET_ERR_CODE(msg->has_label || msg->has_language || msg->has_use_passphrase || msg->has_homescreen)
+  msg->has_language = msg->has_language && strlen(msg->language);
+	if (msg->has_language) {
+		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("change language to"), msg->language, "?", NULL, NULL);
+		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
+			return ErrActionCancelled;;
+		}
+	}
+	if (msg->has_homescreen) {
+		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("change the home"), _("screen?"), NULL, NULL, NULL);
+		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
+			return ErrActionCancelled;;
+		}
+	}
 	if (msg->has_label) {
 		storage_setLabel(msg->label);
 	}

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -71,20 +71,13 @@
 		return; \
 	}
 
-ErrCode_t msgGenerateMnemonicImpl(
-		GenerateMnemonic* msg,
-		void (*random_buffer_func)(uint8_t *buf, size_t len));
+ErrCode_t msgGenerateMnemonicImpl(GenerateMnemonic* msg, void (*random_buffer_func)(uint8_t *buf, size_t len));
 ErrCode_t msgEntropyAckImpl(EntropyAck* msg);
-void msgSkycoinSignMessageImpl(SkycoinSignMessage* msg,
-							ResponseSkycoinSignMessage *msg_resp);
-ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index, 
-										char* signed_message);
-ErrCode_t msgSkycoinAddress(SkycoinAddress* msg, ResponseSkycoinAddress *resp);
-ErrCode_t msgSkycoinCheckMessageSignatureImpl(
-		SkycoinCheckMessageSignature* msg,
-		Success *successResp,
-		Failure *failureResp);
-void msgApplySettings(ApplySettings *msg);
+void msgSkycoinSignMessageImpl(SkycoinSignMessage* msg, ResponseSkycoinSignMessage *msg_resp);
+ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index, char* signed_message);
+ErrCode_t msgSkycoinAddressImpl(SkycoinAddress* msg, ResponseSkycoinAddress *resp);
+ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg, Success *successResp, Failure *failureResp);
+void msgApplySettingsImpl(ApplySettings *msg);
 void msgGetFeaturesImpl(Features *resp);
 
 #endif  // __TINYFIRMWARE_FIRMWARE_FSMIMPL_H__

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -71,13 +71,18 @@
 		return; \
 	}
 
+#define CHECK_PARAM_RET_ERR_CODE(cond) \
+	if (!(cond)) { \
+		return ErrInvalidArg; \
+	}
+
 ErrCode_t msgGenerateMnemonicImpl(GenerateMnemonic* msg, void (*random_buffer_func)(uint8_t *buf, size_t len));
 ErrCode_t msgEntropyAckImpl(EntropyAck* msg);
 void msgSkycoinSignMessageImpl(SkycoinSignMessage* msg, ResponseSkycoinSignMessage *msg_resp);
 ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index, char* signed_message);
 ErrCode_t msgSkycoinAddressImpl(SkycoinAddress* msg, ResponseSkycoinAddress *resp);
 ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg, Success *successResp, Failure *failureResp);
-void msgApplySettingsImpl(ApplySettings *msg);
+ErrCode_t msgApplySettingsImpl(ApplySettings *msg);
 void msgGetFeaturesImpl(Features *resp);
 
 #endif  // __TINYFIRMWARE_FIRMWARE_FSMIMPL_H__

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -25,6 +25,7 @@
 #include "storage.h"
 #include "rng.h"
 
+#include "error.h"
 #include "test_fsm.h"
 
 static uint8_t msg_resp[MSG_OUT_SIZE] __attribute__ ((aligned));
@@ -121,8 +122,7 @@ END_TEST
 START_TEST(test_msgSkycoinSignMessageReturnIsInHex)
 {
 	forceGenerateMnemonic();
-	char raw_msg[] = {
-		"32018964c1ac8c2a536b59dd830a80b9d4ce3bb1ad6a182c13b36240ebf4ec11"};
+	char raw_msg[] = {"32018964c1ac8c2a536b59dd830a80b9d4ce3bb1ad6a182c13b36240ebf4ec11"};
 	SkycoinSignMessage msg = SkycoinSignMessage_init_zero;
 	strncpy(msg.message, raw_msg, sizeof(msg.message));
 	RESP_INIT(ResponseSkycoinSignMessage);
@@ -138,198 +138,195 @@ END_TEST
 
 START_TEST(test_msgSkycoinCheckMessageSignatureOk)
 {
-    // NOTE(denisacostaq@gmail.com): Given
-    forceGenerateMnemonic();
-    SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
-    msgSkyAddress.address_n = 1;
-    uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    ResponseSkycoinAddress *respAddress = 
-            (ResponseSkycoinAddress *) (void *) msg_resp_addr;
-    ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
-    ck_assert_int_eq(ErrOk, err);
-    ck_assert_int_eq(respAddress->addresses_count, 1);
-    // NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
-    // https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
-    char raw_msg[] = {
-        "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
-    SkycoinSignMessage msgSign = SkycoinSignMessage_init_zero;
-    strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
-    msgSign.address_n = 0;
-    
-    // NOTE(denisacostaq@gmail.com): When
-    uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    ResponseSkycoinSignMessage *respSign = 
-            (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
-    msgSkycoinSignMessageImpl(&msgSign, respSign);
-    SkycoinCheckMessageSignature checkMsg = 
-            SkycoinCheckMessageSignature_init_zero;
-    strncpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
-    memcpy(checkMsg.address, respAddress->addresses[0], sizeof(checkMsg.address));
-    memcpy(checkMsg.signature, respSign->signed_message, sizeof(checkMsg.signature));
-    uint8_t msg_success_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    uint8_t msg_fail_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    Success *successRespCheck = (Success *) (void *) msg_success_resp_check;
-    Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
-    err = msgSkycoinCheckMessageSignatureImpl(
-                &checkMsg, successRespCheck, failRespCheck);
+	// NOTE(denisacostaq@gmail.com): Given
+	forceGenerateMnemonic();
+	SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
+	msgSkyAddress.address_n = 1;
+	uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	ResponseSkycoinAddress *respAddress = (ResponseSkycoinAddress *) (void *) msg_resp_addr;
+	ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
+	ck_assert_int_eq(ErrOk, err);
+	ck_assert_int_eq(respAddress->addresses_count, 1);
+	// NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
+	// https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
+	char raw_msg[] = {"66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
+	SkycoinSignMessage msgSign = SkycoinSignMessage_init_zero;
+	strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
+	msgSign.address_n = 0;
 
-    // NOTE(denisacostaq@gmail.com): Then
-    ck_assert_int_eq(ErrOk, err);
-    ck_assert(successRespCheck->has_message);
-    int address_diff = strncmp(
-            respAddress->addresses[0],
-            successRespCheck->message,
-            sizeof(respAddress->addresses[0]));
-    if (address_diff) {
-        fprintf(stderr, "\nrespAddress->addresses[0]: ");
-        for (size_t i = 0; i < sizeof(respAddress->addresses[0]); ++i) {
-            fprintf(stderr, "%c", respAddress->addresses[0][i]);
-        }
-        fprintf(stderr, "\nrespCheck->message: ");
-        for (size_t i = 0; i < sizeof(successRespCheck->message); ++i) {
-            fprintf(stderr, "%c", successRespCheck->message[i]);
-        }
-        fprintf(stderr, "\n");
-    }
-    ck_assert_int_eq(0, address_diff);
+	// NOTE(denisacostaq@gmail.com): When
+	uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	ResponseSkycoinSignMessage *respSign = (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
+	msgSkycoinSignMessageImpl(&msgSign, respSign);
+	SkycoinCheckMessageSignature checkMsg = SkycoinCheckMessageSignature_init_zero;
+	strncpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
+	memcpy(checkMsg.address, respAddress->addresses[0], sizeof(checkMsg.address));
+	memcpy(checkMsg.signature, respSign->signed_message, sizeof(checkMsg.signature));
+	uint8_t msg_success_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	uint8_t msg_fail_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	Success *successRespCheck = (Success *) (void *) msg_success_resp_check;
+	Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
+	err = msgSkycoinCheckMessageSignatureImpl(&checkMsg, successRespCheck, failRespCheck);
+
+	// NOTE(denisacostaq@gmail.com): Then
+	ck_assert_int_eq(ErrOk, err);
+	ck_assert(successRespCheck->has_message);
+	int address_diff = strncmp(
+			respAddress->addresses[0],
+			successRespCheck->message,
+			sizeof(respAddress->addresses[0]));
+	if (address_diff) {
+		fprintf(stderr, "\nrespAddress->addresses[0]: ");
+		for (size_t i = 0; i < sizeof(respAddress->addresses[0]); ++i) {
+			fprintf(stderr, "%c", respAddress->addresses[0][i]);
+		}
+		fprintf(stderr, "\nrespCheck->message: ");
+		for (size_t i = 0; i < sizeof(successRespCheck->message); ++i) {
+			fprintf(stderr, "%c", successRespCheck->message[i]);
+		}
+		fprintf(stderr, "\n");
+	}
+	ck_assert_int_eq(0, address_diff);
 }
 END_TEST
 
 static void swap_char(char *ch1, char *ch2) {
-    char tmp;
-    memcpy((void*)&tmp, (void*)ch1, sizeof (tmp));
-    memcpy((void*)ch1, (void*)ch2, sizeof (*ch1));
-    memcpy((void*)ch2, (void*)&tmp, sizeof (tmp));
+	char tmp;
+	tmp = *ch1;
+	*ch1 = *ch2;
+	*ch2 = tmp;
 }
 
 static void random_shuffle(char *buffer, size_t len) {
-    for (size_t i = 0; i < len; ++i) {
-        size_t rIndex = (size_t)rand() % len;
-        swap_char(&buffer[i], &buffer[rIndex]);
-    }
+	for (size_t i = 0; i < len; ++i) {
+		size_t rIndex = (size_t)rand() % len;
+		swap_char(&buffer[i], &buffer[rIndex]);
+	}
 }
 
 START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedMessage)
 {
-    // NOTE(denisacostaq@gmail.com): Given
-    forceGenerateMnemonic();
-    SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
-    msgSkyAddress.address_n = 1;
-    uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    ResponseSkycoinAddress *respAddress = 
-            (ResponseSkycoinAddress *) (void *) msg_resp_addr;
-    ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
-    ck_assert_int_eq(ErrOk, err);
-    ck_assert_int_eq(respAddress->addresses_count, 1);
-    // NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
-    // https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
-    char raw_msg[] = {
-      "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
-    SkycoinSignMessage msgSign = SkycoinSignMessage_init_zero;
-    strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
-    msgSign.address_n = 0;
+	// NOTE(denisacostaq@gmail.com): Given
+	forceGenerateMnemonic();
+	SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
+	msgSkyAddress.address_n = 1;
+	uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	ResponseSkycoinAddress *respAddress = (ResponseSkycoinAddress *) (void *) msg_resp_addr;
+	ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
+	ck_assert_int_eq(ErrOk, err);
+	ck_assert_int_eq(respAddress->addresses_count, 1);
+	// NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
+	// https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
+	char raw_msg[] = {"66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
+	SkycoinSignMessage msgSign = SkycoinSignMessage_init_zero;
+	strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
+	msgSign.address_n = 0;
 
-    // NOTE(denisacostaq@gmail.com): When
-    uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    ResponseSkycoinSignMessage *respSign = 
-            (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
-    msgSkycoinSignMessageImpl(&msgSign, respSign);
-    // NOTE(denisaostaq@gmail.com): An attacker change our msg signature.
-    random_shuffle(respSign->signed_message, sizeof (respSign->signed_message));
-    SkycoinCheckMessageSignature checkMsg = SkycoinCheckMessageSignature_init_zero;
-    strncpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
-    memcpy(checkMsg.address, respAddress->addresses[0], sizeof(checkMsg.address));
-    memcpy(checkMsg.signature, respSign->signed_message, sizeof(checkMsg.signature));
-    uint8_t msg_success_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    uint8_t msg_fail_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    Success *successRespCheck = (Success *) (void *) msg_success_resp_check;
-    Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
-    err = msgSkycoinCheckMessageSignatureImpl(
-                &checkMsg, successRespCheck, failRespCheck);
+	// NOTE(denisacostaq@gmail.com): When
+	uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	ResponseSkycoinSignMessage *respSign = (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
+	msgSkycoinSignMessageImpl(&msgSign, respSign);
+	// NOTE(denisaostaq@gmail.com): An attacker change our msg signature.
+	random_shuffle(respSign->signed_message, sizeof (respSign->signed_message));
+	SkycoinCheckMessageSignature checkMsg = SkycoinCheckMessageSignature_init_zero;
+	strncpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
+	memcpy(checkMsg.address, respAddress->addresses[0], sizeof(checkMsg.address));
+	memcpy(checkMsg.signature, respSign->signed_message, sizeof(checkMsg.signature));
+	uint8_t msg_success_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	uint8_t msg_fail_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	Success *successRespCheck = (Success *) (void *) msg_success_resp_check;
+	Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
+	err = msgSkycoinCheckMessageSignatureImpl(&checkMsg, successRespCheck, failRespCheck);
 
-    // NOTE(denisacostaq@gmail.com): Then
-    ck_assert_int_ne(ErrOk, err);
-    ck_assert(failRespCheck->has_message);
-    int address_diff = strncmp(
-            respAddress->addresses[0], 
-            successRespCheck->message,
-            sizeof(respAddress->addresses[0]));
-    ck_assert_int_ne(0, address_diff);
+	// NOTE(denisacostaq@gmail.com): Then
+	ck_assert_int_ne(ErrOk, err);
+	ck_assert(failRespCheck->has_message);
+	int address_diff = strncmp(
+			respAddress->addresses[0], 
+			successRespCheck->message,
+			sizeof(respAddress->addresses[0]));
+	ck_assert_int_ne(0, address_diff);
 }
 END_TEST
 
 START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage)
 {
-    // NOTE(denisacostaq@gmail.com): Given
-    forceGenerateMnemonic();
-    SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
-    msgSkyAddress.address_n = 1;
-    uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    ResponseSkycoinAddress *respAddress = 
-            (ResponseSkycoinAddress *) (void *) msg_resp_addr;
-    ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
-    ck_assert_int_eq(ErrOk, err);
-    ck_assert_int_eq(respAddress->addresses_count, 1);
-    // NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
-    // https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
-    char raw_msg[] = {
-      "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
-    SkycoinSignMessage msgSign = SkycoinSignMessage_init_zero;
-    strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
-    msgSign.address_n = 0;
+	// NOTE(denisacostaq@gmail.com): Given
+	forceGenerateMnemonic();
+	SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
+	msgSkyAddress.address_n = 1;
+	uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	ResponseSkycoinAddress *respAddress = (ResponseSkycoinAddress *) (void *) msg_resp_addr;
+	ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
+	ck_assert_int_eq(ErrOk, err);
+	ck_assert_int_eq(respAddress->addresses_count, 1);
+	// NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
+	// https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
+	char raw_msg[] = {"66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
+	SkycoinSignMessage msgSign = SkycoinSignMessage_init_zero;
+	strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
+	msgSign.address_n = 0;
 
-    // NOTE(denisacostaq@gmail.com): When
-    uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    ResponseSkycoinSignMessage *respSign = 
-            (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
-    msgSkycoinSignMessageImpl(&msgSign, respSign);
-    // NOTE(denisaostaq@gmail.com): An attacker change our msg(hash).
-    random_shuffle(msgSign.message, sizeof (msgSign.message));
-    SkycoinCheckMessageSignature checkMsg = SkycoinCheckMessageSignature_init_zero;
-    strncpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
-    memcpy(checkMsg.address, respAddress->addresses[0], sizeof(checkMsg.address));
-    memcpy(checkMsg.signature, respSign->signed_message, sizeof(checkMsg.signature));
-    uint8_t msg_success_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    uint8_t msg_fail_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
-    Success *successRespCheck = (Success *) (void *) msg_success_resp_check;
-    Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
-    err = msgSkycoinCheckMessageSignatureImpl(
-                &checkMsg, successRespCheck, failRespCheck);
+	// NOTE(denisacostaq@gmail.com): When
+	uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	ResponseSkycoinSignMessage *respSign = (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
+	msgSkycoinSignMessageImpl(&msgSign, respSign);
+	// NOTE(denisaostaq@gmail.com): An attacker change our msg(hash).
+	random_shuffle(msgSign.message, sizeof (msgSign.message));
+	SkycoinCheckMessageSignature checkMsg = SkycoinCheckMessageSignature_init_zero;
+	strncpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
+	memcpy(checkMsg.address, respAddress->addresses[0], sizeof(checkMsg.address));
+	memcpy(checkMsg.signature, respSign->signed_message, sizeof(checkMsg.signature));
+	uint8_t msg_success_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	uint8_t msg_fail_resp_check[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
+	Success *successRespCheck = (Success *) (void *) msg_success_resp_check;
+	Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
+	err = msgSkycoinCheckMessageSignatureImpl(&checkMsg, successRespCheck, failRespCheck);
 
-    // NOTE(denisacostaq@gmail.com): Then
-    ck_assert_int_ne(ErrOk, err);
-    ck_assert(failRespCheck->has_message);
-    int address_diff = strncmp(
-            respAddress->addresses[0], 
-            successRespCheck->message,
-            sizeof(respAddress->addresses[0]));
-    ck_assert_int_ne(0, address_diff);
+	// NOTE(denisacostaq@gmail.com): Then
+	ck_assert_int_ne(ErrOk, err);
+	ck_assert(failRespCheck->has_message);
+	int address_diff = strncmp(
+			respAddress->addresses[0], 
+			successRespCheck->message,
+			sizeof(respAddress->addresses[0]));
+	ck_assert_int_ne(0, address_diff);
 }
 END_TEST
 
 START_TEST(test_msgApplySettingsLabelSuccess)
 {
-    storage_wipe();
-    char raw_label[] = {
-        "my custom device label"};
-    ApplySettings msg = ApplySettings_init_zero;
-    msg.has_label = true;
-    strncpy(msg.label, raw_label, sizeof(msg.label));
-    msgApplySettingsImpl(&msg);
-    ck_assert_int_eq(storage_hasLabel(), 1);
-    ck_assert_str_eq(storage_getLabel(), raw_label);
+	storage_wipe();
+	char raw_label[] = {"my custom device label"};
+	ApplySettings msg = ApplySettings_init_zero;
+	msg.has_label = true;
+	strncpy(msg.label, raw_label, sizeof(msg.label));
+	ErrCode_t err = msgApplySettingsImpl(&msg);
+	ck_assert_int_eq((int) err, (int) ErrOk);
+	ck_assert_int_eq(storage_hasLabel(), true);
+	ck_assert_str_eq(storage_getLabel(), raw_label);
 }
 END_TEST
 
 START_TEST(test_msgApplySettingsLabelSuccessCheck)
 {
 	storage_wipe();
-	char raw_label[] = {
-		"my custom device label"};
+	char* raw_label = "my custom device label";
 	ApplySettings msg = ApplySettings_init_zero;
-	strncpy(msg.label, raw_label, sizeof(msg.label));
-	msgApplySettingsImpl(&msg);
+	strncpy(msg.label, raw_label, strlen(msg.label));
+	ErrCode_t err = msgApplySettingsImpl(&msg);
+	ck_assert_int_eq((int) err, (int) ErrInvalidArg);
 	ck_assert_int_eq(storage_hasLabel(), true);
+	ck_assert_str_ne(storage_getLabel(), raw_label);
+}
+END_TEST
+
+START_TEST(test_msgApplySettingsLabelFailureNoChanges)
+{
+	storage_wipe();
+	ApplySettings msg = ApplySettings_init_zero;
+	ErrCode_t err = msgApplySettingsImpl(&msg);
+	ck_assert_int_eq(err, ErrInvalidArg);
 }
 END_TEST
 
@@ -363,20 +360,15 @@ TCase *add_fsm_tests(TCase *tc)
 	tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFailIfItWasDone);
 	tcase_add_test(tc, test_msgSkycoinCheckMessageSignatureOk);
 	tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFailForWrongSeedCount);
-	tcase_add_test(
-		tc,
-		test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedMessage);
-	tcase_add_test(
-		tc, 
-		test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage);
+	tcase_add_test(tc, test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedMessage);
+	tcase_add_test(tc, test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage);
 	tcase_add_test(tc, test_msgApplySettingsLabelSuccess);
+	tcase_add_test(tc, test_msgApplySettingsLabelSuccessCheck);
+	tcase_add_test(tc, test_msgApplySettingsLabelFailureNoChanges);
 	tcase_add_test(tc, test_msgFeaturesLabelDefaultsToDeviceId);
 	tcase_add_test(tc, test_msgGetFeatures);
-	tcase_add_test(tc, test_msgApplySettingsLabelSuccessCheck);
 	tcase_add_test(tc, test_msgFeaturesLabelDefaultsToDeviceId);
-	tcase_add_test(
-		tc, 
-		test_msgEntropyAckImplFailAsExpectedForSyncProblemInProtocol);
+	tcase_add_test(tc, test_msgEntropyAckImplFailAsExpectedForSyncProblemInProtocol);
 	tcase_add_test(tc, test_msgGenerateMnemonicEntropyAckSequenceShouldBeOk);
 	return tc;
 }

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -318,7 +318,7 @@ START_TEST(test_msgApplySettingsLabelShouldNotBeRemovable)
     msg.use_passphrase = false;
     msg.has_label = true;
     strncpy(msg.label, raw_label, sizeof(msg.label));
-    msgApplySettings(&msg);
+    msgApplySettingsImpl(&msg);
     ck_assert(!storage_hasPassphraseProtection());
     ck_assert_int_eq(storage_hasLabel(), true);
     ck_assert_str_eq(storage_getLabel(), raw_label);
@@ -326,7 +326,7 @@ START_TEST(test_msgApplySettingsLabelShouldNotBeRemovable)
     memset(msg.label, 0, sizeof(msg.label));
     msg.has_use_passphrase = true;
     msg.use_passphrase = true;
-    msgApplySettings(&msg);
+    msgApplySettingsImpl(&msg);
     ck_assert_str_eq(storage_getLabel(), raw_label);
     ck_assert(storage_hasPassphraseProtection());
 }

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -145,7 +145,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureOk)
     uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
     ResponseSkycoinAddress *respAddress = 
             (ResponseSkycoinAddress *) (void *) msg_resp_addr;
-    ErrCode_t err = msgSkycoinAddress(&msgSkyAddress, respAddress);
+    ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
     ck_assert_int_eq(ErrOk, err);
     ck_assert_int_eq(respAddress->addresses_count, 1);
     // NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
@@ -218,7 +218,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedM
     uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
     ResponseSkycoinAddress *respAddress = 
             (ResponseSkycoinAddress *) (void *) msg_resp_addr;
-    ErrCode_t err = msgSkycoinAddress(&msgSkyAddress, respAddress);
+    ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
     ck_assert_int_eq(ErrOk, err);
     ck_assert_int_eq(respAddress->addresses_count, 1);
     // NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
@@ -267,7 +267,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage
     uint8_t msg_resp_addr[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
     ResponseSkycoinAddress *respAddress = 
             (ResponseSkycoinAddress *) (void *) msg_resp_addr;
-    ErrCode_t err = msgSkycoinAddress(&msgSkyAddress, respAddress);
+    ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
     ck_assert_int_eq(ErrOk, err);
     ck_assert_int_eq(respAddress->addresses_count, 1);
     // NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
@@ -315,7 +315,7 @@ START_TEST(test_msgApplySettingsLabelSuccess)
     ApplySettings msg = ApplySettings_init_zero;
     msg.has_label = true;
     strncpy(msg.label, raw_label, sizeof(msg.label));
-    msgApplySettings(&msg);
+    msgApplySettingsImpl(&msg);
     ck_assert_int_eq(storage_hasLabel(), 1);
     ck_assert_str_eq(storage_getLabel(), raw_label);
 }
@@ -328,7 +328,7 @@ START_TEST(test_msgApplySettingsLabelSuccessCheck)
 		"my custom device label"};
 	ApplySettings msg = ApplySettings_init_zero;
 	strncpy(msg.label, raw_label, sizeof(msg.label));
-	msgApplySettings(&msg);
+	msgApplySettingsImpl(&msg);
 	ck_assert_int_eq(storage_hasLabel(), true);
 }
 END_TEST


### PR DESCRIPTION
Fixes #142

Changes:
- Refactored functions in `fsm.c` for unit testing and added macros to simplify the code (Eg. `CHECK_PARAMS_RET_ERR_CODE`, `CHECK_BUTTON_PROTECT` and so on)

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
yes

Comments about testing , should you have some
