### PR TITLE
fixes #123 - Deactivate skycoin sign message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Disable signing of generic messages.
+
 ### Removed
 
 - Installation instructions for `protobuf` related tools, use this from `hardware-wallet-protob` submodule.
 - Remove support to recover device from words matrix. The only support method is scrambled words.
 - Not possible to enforce BIP-39 wordlist during recovery process.
 - Not possible to perform dry-run recovery workflow (for safe mnemonic validation)
-
-### Fixed
 
 ### Security
 

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -55,6 +55,11 @@ extern uint8_t  int_entropy[INTERNAL_ENTROPY_SIZE];
 static bool has_passphrase_protection;
 static bool passphrase_protection;
 
+ErrCode_t msgNotImplementedImpl(void *msg) {
+	return ErrNotImplemented;
+}
+
+
 ErrCode_t msgEntropyAckImpl(EntropyAck* msg) {
 	_Static_assert(EXTERNAL_ENTROPY_MAX_SIZE == sizeof(msg->entropy.bytes),
 					"External entropy size does not match.");
@@ -119,30 +124,33 @@ ErrCode_t msgGenerateMnemonicImpl(
 ErrCode_t msgSkycoinSignMessageImpl(SkycoinSignMessage* msg,
 								   ResponseSkycoinSignMessage *resp)
 {
-	CHECK_MNEMONIC_RET_ERR_CODE
-	CHECK_PIN_UNCACHED_RET_ERR_CODE
-	uint8_t pubkey[33] = {0};
-	uint8_t seckey[32] = {0};
-	fsm_getKeyPairAtIndex(1, pubkey, seckey, NULL, msg->address_n);
-	uint8_t digest[32] = {0};
-	if (is_digest(msg->message) == false) {
-		compute_sha256sum((const uint8_t *)msg->message, digest, strlen(msg->message));
-	} else {
-		writebuf_fromhexstr(msg->message, digest);
-	}
-	uint8_t signature[65];
-	int res = ecdsa_skycoin_sign(random32(), seckey, digest, signature);
-	if (res == 0) {
-		layoutRawMessage("Signature success");
-	} else {
-		layoutRawMessage("Signature failed");
-	}
-	const size_t hex_len = 2 * sizeof(signature);
-	char signature_in_hex[hex_len];
-	tohex(signature_in_hex, signature, sizeof(signature));
-	memcpy(resp->signed_message, signature_in_hex, hex_len);
-	msg_write(MessageType_MessageType_ResponseSkycoinSignMessage, resp);
-	return ErrOk;
+	// Message temporarily disabled
+	return msgNotImplementedImpl((void *)msg);
+
+//	CHECK_MNEMONIC_RET_ERR_CODE
+//	CHECK_PIN_UNCACHED_RET_ERR_CODE
+//	uint8_t pubkey[33] = {0};
+//	uint8_t seckey[32] = {0};
+//	fsm_getKeyPairAtIndex(1, pubkey, seckey, NULL, msg->address_n);
+//	uint8_t digest[32] = {0};
+//	if (is_digest(msg->message) == false) {
+//		compute_sha256sum((const uint8_t *)msg->message, digest, strlen(msg->message));
+//	} else {
+//		writebuf_fromhexstr(msg->message, digest);
+//	}
+//	uint8_t signature[65];
+//	int res = ecdsa_skycoin_sign(random32(), seckey, digest, signature);
+//	if (res == 0) {
+//		layoutRawMessage("Signature success");
+//	} else {
+//		layoutRawMessage("Signature failed");
+//	}
+//	const size_t hex_len = 2 * sizeof(signature);
+//	char signature_in_hex[hex_len];
+//	tohex(signature_in_hex, signature, sizeof(signature));
+//	memcpy(resp->signed_message, signature_in_hex, hex_len);
+//	msg_write(MessageType_MessageType_ResponseSkycoinSignMessage, resp);
+//	return ErrOk;
 }
 
 ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index, char* signed_message) {

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -129,26 +129,23 @@
 		return ErrInvalidValue; \
 	}
 
-ErrCode_t msgGenerateMnemonicImpl(
-		GenerateMnemonic* msg,
-		void (*random_buffer_func)(uint8_t *buf, size_t len));
+ErrCode_t msgApplySettingsImpl(ApplySettings *msg);
+ErrCode_t msgBackupDeviceImpl(BackupDevice *msg, ErrCode_t (*)(void));
+ErrCode_t msgChangePinImpl(ChangePin *msg, bool (*)(void));
 ErrCode_t msgEntropyAckImpl(EntropyAck* msg);
-ErrCode_t msgSkycoinSignMessageImpl(SkycoinSignMessage* msg,
-							ResponseSkycoinSignMessage *msg_resp);
-ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index,
-										char* signed_message);
+ErrCode_t msgGenerateMnemonicImpl(GenerateMnemonic* msg, void (*random_buffer_func)(uint8_t *buf, size_t len));
+ErrCode_t msgGetEntropyImpl(GetEntropy *msg);
+ErrCode_t msgGetFeaturesImpl(Features *resp);
+ErrCode_t msgLoadDeviceImpl(LoadDevice *msg);
+ErrCode_t msgNotImplementedImpl(void *msg);
+ErrCode_t msgPingImpl(Ping *msg);
+ErrCode_t msgRecoveryDeviceImpl(RecoveryDevice *msg, ErrCode_t (*)(void));
+ErrCode_t msgSetMnemonicImpl(SetMnemonic *msg);
+ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index, char* signed_message);
 ErrCode_t msgSkycoinAddressImpl(SkycoinAddress* msg, ResponseSkycoinAddress *resp);
 ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg, Success *successResp, Failure *failureResp);
-ErrCode_t msgApplySettingsImpl(ApplySettings *msg);
-ErrCode_t msgGetFeaturesImpl(Features *resp);
+ErrCode_t msgSkycoinSignMessageImpl(SkycoinSignMessage* msg, ResponseSkycoinSignMessage *msg_resp);
 ErrCode_t msgTransactionSignImpl(TransactionSign *msg, ErrCode_t (*)(char*, char *, TransactionSign*, uint32_t));
-ErrCode_t msgPingImpl(Ping *msg);
-ErrCode_t msgChangePinImpl(ChangePin *msg, bool (*)(void));
 ErrCode_t msgWipeDeviceImpl(WipeDevice *msg);
-ErrCode_t msgSetMnemonicImpl(SetMnemonic *msg);
-ErrCode_t msgGetEntropyImpl(GetEntropy *msg);
-ErrCode_t msgLoadDeviceImpl(LoadDevice *msg);
-ErrCode_t msgBackupDeviceImpl(BackupDevice *msg, ErrCode_t (*)(void));
-ErrCode_t msgRecoveryDeviceImpl(RecoveryDevice *msg, ErrCode_t (*)(void));
 
 #endif  // __TINYFIRMWARE_FIRMWARE_FSMIMPL_H__

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -45,7 +45,7 @@ void forceGenerateMnemonic(void) {
 	ck_assert_int_eq(ErrOk, msgGenerateMnemonicImpl(&msg, &random_buffer));
 }
 
-bool is_a_base16_caharacter(char c) {
+bool is_base_16_char(char c) {
 	if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
 		return true;
 	}
@@ -131,7 +131,7 @@ START_TEST(test_msgSkycoinSignMessageReturnIsInHex)
 	// 2 for each one in hex = 130
 	// TODO(denisacostaq@gmail.com): this kind of "dependency" is not maintainable.
 	for (size_t i = 0; i < sizeof(resp->signed_message); ++i) {
-		ck_assert(is_a_base16_caharacter(resp->signed_message[i]));
+		ck_assert(is_base_16_char(resp->signed_message[i]));
 	}
 }
 END_TEST


### PR DESCRIPTION
Fixes #123 

Changes:
- Sign message fails as not implemented

Does this change need to mentioned in CHANGELOG.md?
yes

Requires changes in protobuff specs?
no

Requires testing
yes

see `test_fsm.c` .
