### PR TITLE
grab sdl2 include automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ before_script:
     echo "PIP=$PIP";
     fi
   # Define env vars for osx builds
+  # Install OS-specific test and build dependencies
+  - eval "./ci-scripts/install-${TRAVIS_OS_NAME}.sh"
   # Include paths for brew packages e.g. SDL2
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     export CHECK_PATH="$(brew --prefix check)" ;
     export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${CHECK_PATH}/lib" ;
-    export SDL_INCLUDE="$(brew --prefix sdl2)/include/SDL2" ;
+    export SDL_INCLUDE="$(exec sdl2-config --cflags | sed 's/-D_THREAD_SAFE//g')" ;
     fi
-  # Install OS-specific test and build dependencies
-  - eval "./ci-scripts/install-${TRAVIS_OS_NAME}.sh"
   # Install linters
   - make install-linters
 script:

--- a/ci-scripts/install-osx.sh
+++ b/ci-scripts/install-osx.sh
@@ -12,5 +12,5 @@ brew install check
 brew install md5sha1sum curl unzip python gcc-arm-none-eabi
 
 # Install SDL
-brew install  sdl2_image sdl2 mesa mesalib-glw
+brew install sdl2_image sdl2 mesa mesalib-glw
 

--- a/tiny-firmware/Makefile
+++ b/tiny-firmware/Makefile
@@ -1,6 +1,6 @@
 APPVER = 1.0.0
 
-SDL_INCLUDE := $(shell sdl2-config --cflags)
+SDL_INCLUDE ?= $(shell sdl2-config --cflags)
 
 #libtrezor.a
 ifneq ($(EMULATOR),1)
@@ -117,7 +117,7 @@ CFLAGS   += -DHEADLESS=1
 else
 CFLAGS   += -DHEADLESS=0
 
-CFLAGS   += $(SDL_INCLUDE)
+CFLAGS   += $(SDL_INCLUDE) -D_REENTRANT
 LDLIBS   += -lSDL2
 endif
 endif

--- a/tiny-firmware/Makefile
+++ b/tiny-firmware/Makefile
@@ -1,6 +1,6 @@
 APPVER = 1.0.0
 
-SDL_INCLUDE ?= $(shell sdl2-config --cflags)
+SDL_INCLUDE ?= $(shell sdl2-config --cflags | sed 's/-D_THREAD_SAFE//g')
 
 #libtrezor.a
 ifneq ($(EMULATOR),1)

--- a/tiny-firmware/Makefile
+++ b/tiny-firmware/Makefile
@@ -1,6 +1,6 @@
 APPVER = 1.0.0
 
-SDL_INCLUDE ?= /usr/include/SDL2
+SDL_INCLUDE := $(shell sdl2-config --cflags)
 
 #libtrezor.a
 ifneq ($(EMULATOR),1)
@@ -117,7 +117,7 @@ CFLAGS   += -DHEADLESS=1
 else
 CFLAGS   += -DHEADLESS=0
 
-CFLAGS   += -I$(SDL_INCLUDE) -D_REENTRANT
+CFLAGS   += $(SDL_INCLUDE)
 LDLIBS   += -lSDL2
 endif
 endif

--- a/tiny-firmware/emulator/Makefile
+++ b/tiny-firmware/emulator/Makefile
@@ -1,7 +1,7 @@
 EMULATOR := 1
 UNAME_S := $(shell uname -s)
 
-SDL_INCLUDE := $(shell sdl2-config --cflags)
+SDL_INCLUDE ?= $(shell sdl2-config --cflags)
 
 TOOLCHAIN_DIR ?= $(TOP_DIR)vendor/libopencm3
 
@@ -18,7 +18,7 @@ ifeq ($(HEADLESS),1)
 CFLAGS   += -DHEADLESS=1
 else
 CFLAGS   += -DHEADLESS=0
-CFLAGS   += $(SDL_INCLUDE)
+CFLAGS   += $(SDL_INCLUDE) -D_REENTRANT
 CFLAGS   += -I$(TOOLCHAIN_DIR)/include
 LDLIBS   += -lSDL2
 endif

--- a/tiny-firmware/emulator/Makefile
+++ b/tiny-firmware/emulator/Makefile
@@ -1,7 +1,7 @@
 EMULATOR := 1
 UNAME_S := $(shell uname -s)
 
-SDL_INCLUDE ?= $(shell sdl2-config --cflags)
+SDL_INCLUDE ?= $(shell sdl2-config --cflags | sed 's/-D_THREAD_SAFE//g')
 
 TOOLCHAIN_DIR ?= $(TOP_DIR)vendor/libopencm3
 

--- a/tiny-firmware/emulator/Makefile
+++ b/tiny-firmware/emulator/Makefile
@@ -1,7 +1,8 @@
 EMULATOR := 1
 UNAME_S := $(shell uname -s)
 
-SDL_INCLUDE ?= /usr/include/SDL2
+SDL_INCLUDE := $(shell sdl2-config --cflags)
+
 TOOLCHAIN_DIR ?= $(TOP_DIR)vendor/libopencm3
 
 CFLAGS += -DEMULATOR=1
@@ -17,7 +18,8 @@ ifeq ($(HEADLESS),1)
 CFLAGS   += -DHEADLESS=1
 else
 CFLAGS   += -DHEADLESS=0
-CFLAGS   += -I$(SDL_INCLUDE) -I$(TOOLCHAIN_DIR)/include -D_REENTRANT
+CFLAGS   += $(SDL_INCLUDE)
+CFLAGS   += -I$(TOOLCHAIN_DIR)/include
 LDLIBS   += -lSDL2
 endif
 


### PR DESCRIPTION
Fixes: automatically grab sdl2 include path

Note: on macOS sdl2-config returns:
`-I/usr/local/include/SDL2 -D_THREAD_SAFE`
while on ubuntu it returns:
`-I/usr/local/include/SDL2 -D_REENTRANT`

what is the difference between the two?

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no