### PR TITLE
refs #151 - Improve transaction input signing and apply settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ In order to identify at first sight the features supported by a particular relea
 The project includes a test suite. In order to run it just execute the following command
 
 ```
-make test
+make clean && make test
 ```
 
 ### Validate the TRNG

--- a/tiny-firmware/bootloader/bootloader.c
+++ b/tiny-firmware/bootloader/bootloader.c
@@ -125,7 +125,7 @@ void bootloader_loop(void)
 	oledDrawBitmap(0, 0, &bmp_logo64);
 	if (firmware_present()) {
 		oledDrawString(52, 0, "SKYCOIN", FONT_STANDARD);
-		// NOTE(denisacostaq@gmail.com): *2 due to the hex formad and +1 because of the trailing NUL char
+		// NOTE(): *2 due to the hex formad and +1 because of the trailing NUL char
 		static char serial[SERIAL_NUMBER_SIZE*2 + 1];
 		fill_serialno_fixed(serial);
 		oledDrawString(52, 20, "Serial No.", FONT_STANDARD);

--- a/tiny-firmware/emulator/emulator.h
+++ b/tiny-firmware/emulator/emulator.h
@@ -25,7 +25,7 @@
 #include <stddef.h>
 
 #if !defined(__APPLE__) && !defined(TARGET_OS_MAC)
-#include "strl.h"  // NOTE(denisacostaq@gmail.com): This file is not required by BSD family(Darwin)
+#include "strl.h"  // NOTE(): This file is not required by BSD family(Darwin)
 #endif  // !defined(__APPLE__) && !defined(TARGET_OS_MAC)
 
 void emulatorPoll(void);

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -262,7 +262,16 @@ void fsm_msgApplySettings(ApplySettings *msg)
 		CHECK_BUTTON_PROTECT
 	}
 
-	fsm_sendResponseFromErrCode(msgApplySettingsImpl(msg), _("Settings applied"), NULL);
+	ErrCode_t err = msgApplySettingsImpl(msg);
+	char *failMsg = NULL;
+	switch (err) {
+		case ErrInvalidArg:
+			failMsg = _("No setting provided");
+			break;
+		default:
+			break;
+	}
+	fsm_sendResponseFromErrCode(err, _("Settings applied"), failMsg);
 	layoutHome();
 }
 
@@ -304,16 +313,16 @@ void fsm_msgTransactionSign(TransactionSign* msg) {
 	RESP_INIT(ResponseTransactionSign);
 	ErrCode_t err = msgTransactionSignImpl(msg, &requestConfirmTransaction, resp);
 	char* failMsg = NULL;
-  switch (err) {
-    case ErrOk:
-	    msg_write(MessageType_MessageType_ResponseTransactionSign, resp);
-      break;
-    case ErrAddressGeneration:
-		  failMsg = _("Wrong return address");
-      // fall through
-    default:
-	    fsm_sendResponseFromErrCode(err, NULL, failMsg);
-      break;
+	switch (err) {
+		case ErrOk:
+			msg_write(MessageType_MessageType_ResponseTransactionSign, resp);
+			break;
+		case ErrAddressGeneration:
+			failMsg = _("Wrong return address");
+			// fall through
+		default:
+			fsm_sendResponseFromErrCode(err, NULL, failMsg);
+			break;
 	}
 	layoutHome();
 }
@@ -464,8 +473,8 @@ void fsm_msgGetMixedEntropy(GetMixedEntropy *_msg) {
 	CHECK_BUTTON_PROTECT
 #endif  // DISABLE_GETENTROPY_CONFIRM
 	RESP_INIT(Entropy);
-  GetRawEntropy msg;
-  msg.size = _msg->size;
+	GetRawEntropy msg;
+	msg.size = _msg->size;
 	ErrCode_t ret = msgGetEntropyImpl(&msg, resp, &random_salted_buffer);
 	if (ret == ErrOk) {
 		msg_write(MessageType_MessageType_Entropy, resp);

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -300,15 +300,22 @@ void fsm_msgTransactionSign(TransactionSign* msg) {
 	CHECK_MNEMONIC
 	CHECK_INPUTS(msg)
 	CHECK_OUTPUTS(msg)
-	ErrCode_t err = msgTransactionSignImpl(msg, &requestConfirmTransaction);
+
+	RESP_INIT(ResponseTransactionSign);
+	ErrCode_t err = msgTransactionSignImpl(msg, &requestConfirmTransaction, resp);
 	char* failMsg = NULL;
-	if (err == ErrAddressGeneration) {
-		failMsg = _("Wrong return address");
+  switch (err) {
+    case ErrOk:
+	    msg_write(MessageType_MessageType_ResponseTransactionSign, resp);
+      break;
+    case ErrAddressGeneration:
+		  failMsg = _("Wrong return address");
+      // fall through
+    default:
+	    fsm_sendResponseFromErrCode(err, NULL, failMsg);
+      break;
 	}
-	fsm_sendResponseFromErrCode(err, NULL, failMsg);
-	if (err != ErrActionCancelled) {
-		layoutHome();
-	}
+	layoutHome();
 }
 
 void fsm_msgSkycoinSignMessage(SkycoinSignMessage *msg)

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -290,7 +290,7 @@ ErrCode_t msgGetFeaturesImpl(Features *resp)
 	return ErrOk;
 }
 
-ErrCode_t msgTransactionSignImpl(TransactionSign *msg, ErrCode_t (*funcConfirmTxn)(char*, char *, TransactionSign*, uint32_t)) {
+ErrCode_t msgTransactionSignImpl(TransactionSign *msg, ErrCode_t (*funcConfirmTxn)(char*, char *, TransactionSign*, uint32_t), ResponseTransactionSign *resp) {
 	#if EMULATOR
 		printf("%s: %d. nbOut: %d\n",
 			_("Transaction signed nbIn"),
@@ -353,7 +353,6 @@ ErrCode_t msgTransactionSignImpl(TransactionSign *msg, ErrCode_t (*funcConfirmTx
 
 	CHECK_PIN_UNCACHED_RET_ERR_CODE
 
-	RESP_INIT(ResponseTransactionSign);
 	for (uint32_t i = 0; i < msg->nbIn; ++i) {
 		uint8_t digest[32];
 		transaction_msgToSign(&transaction, i, digest);
@@ -385,7 +384,6 @@ ErrCode_t msgTransactionSignImpl(TransactionSign *msg, ErrCode_t (*funcConfirmTx
 		printf("Signed message:  %s\n", resp->signatures[0]);
 		printf("Nb signatures: %d\n", resp->signatures_count);
 	#endif
-	msg_write(MessageType_MessageType_ResponseTransactionSign, resp);
 	//layoutHome();
 	return ErrOk;
 }

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -196,13 +196,13 @@ ErrCode_t msgSkycoinAddressImpl(SkycoinAddress* msg, ResponseSkycoinAddress *res
 
 ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg, Success *successResp, Failure *failureResp)
 {
-	// NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
+	// NOTE(): -1 because the end of string ('\0')
 	// /2 because the hex to buff conversion.
 	uint8_t sign[(sizeof(msg->signature) - 1)/2];
-	// NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
+	// NOTE(): -1 because the end of string ('\0')
 	char pubkeybase58[sizeof(msg->address) - 1];
 	uint8_t pubkey[33] = {0};
-	// NOTE(denisacostaq@gmail.com): -1 because the end of string ('\0')
+	// NOTE(): -1 because the end of string ('\0')
 	// /2 because the hex to buff conversion.
 	uint8_t digest[(sizeof(msg->message) - 1) / 2] = {0};
 	//     RESP_INIT(Success);

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -144,7 +144,7 @@ ErrCode_t msgSkycoinAddressImpl(SkycoinAddress* msg, ResponseSkycoinAddress *res
 ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg, Success *successResp, Failure *failureResp);
 ErrCode_t msgApplySettingsImpl(ApplySettings *msg);
 ErrCode_t msgGetFeaturesImpl(Features *resp);
-ErrCode_t msgTransactionSignImpl(TransactionSign *msg, ErrCode_t (*)(char*, char *, TransactionSign*, uint32_t));
+ErrCode_t msgTransactionSignImpl(TransactionSign *msg, ErrCode_t (*)(char*, char *, TransactionSign*, uint32_t), ResponseTransactionSign*);
 ErrCode_t msgPingImpl(Ping *msg);
 ErrCode_t msgChangePinImpl(ChangePin *msg, const char* (*)(PinMatrixRequestType, const char *));
 ErrCode_t msgWipeDeviceImpl(WipeDevice *msg);

--- a/tiny-firmware/firmware/layout2.c
+++ b/tiny-firmware/firmware/layout2.c
@@ -129,7 +129,7 @@ void layoutHome(void)
 			oledBox(0, 0, 127, 8, false);
 			oledDrawStringCenter(0, "NEEDS BACKUP!", FONT_STANDARD);
 		} else {
-				// NOTE(denisacostaq@gmail.com): The screen is not long enough
+				// NOTE(): The screen is not long enough
 				// so clip the device label string.
 				char devLabel[MAX(sizeof (storageUpdate.label), 
 								sizeof (storage_uuid_str))];

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -125,9 +125,9 @@ START_TEST(test_msgSkycoinSignMessageReturnIsInHex)
 	strncpy(msg.message, raw_msg, sizeof(msg.message));
 	RESP_INIT(ResponseSkycoinSignMessage);
 	msgSkycoinSignMessageImpl(&msg, resp);
-	// NOTE(denisacostaq@gmail.com): ecdsa signature have 65 bytes,
+	// NOTE(): ecdsa signature have 65 bytes,
 	// 2 for each one in hex = 130
-	// TODO(denisacostaq@gmail.com): this kind of "dependency" is not maintainable.
+	// TODO(): this kind of "dependency" is not maintainable.
 	for (size_t i = 0; i < sizeof(resp->signed_message); ++i) {
 		ck_assert(is_a_base16_caharacter(resp->signed_message[i]));
 	}
@@ -136,7 +136,7 @@ END_TEST
 
 START_TEST(test_msgSkycoinCheckMessageSignatureOk)
 {
-	// NOTE(denisacostaq@gmail.com): Given
+	// NOTE(): Given
 	forceGenerateMnemonic();
 	SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
 	msgSkyAddress.address_n = 1;
@@ -145,7 +145,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureOk)
 	ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
 	ck_assert_int_eq(ErrOk, err);
 	ck_assert_int_eq(respAddress->addresses_count, 1);
-	// NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
+	// NOTE(): `raw_msg` hash become from:
 	// https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
 	char raw_msg[] = {
 		"66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
@@ -153,7 +153,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureOk)
 	strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
 	msgSign.address_n = 0;
 	
-	// NOTE(denisacostaq@gmail.com): When
+	// NOTE(): When
 	uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
 	ResponseSkycoinSignMessage *respSign = (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
 	msgSkycoinSignMessageImpl(&msgSign, respSign);
@@ -167,7 +167,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureOk)
 	Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
 	err = msgSkycoinCheckMessageSignatureImpl(&checkMsg, successRespCheck, failRespCheck);
 
-	// NOTE(denisacostaq@gmail.com): Then
+	// NOTE(): Then
 	ck_assert_int_eq(ErrOk, err);
 	ck_assert(successRespCheck->has_message);
 	int address_diff = strncmp(
@@ -205,7 +205,7 @@ static void random_shuffle(char *buffer, size_t len) {
 
 START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedMessage)
 {
-	// NOTE(denisacostaq@gmail.com): Given
+	// NOTE(): Given
 	forceGenerateMnemonic();
 	SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
 	msgSkyAddress.address_n = 1;
@@ -214,14 +214,14 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedM
 	ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
 	ck_assert_int_eq(ErrOk, err);
 	ck_assert_int_eq(respAddress->addresses_count, 1);
-	// NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
+	// NOTE(): `raw_msg` hash become from:
 	// https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
 	char raw_msg[] = {"66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
 	SkycoinSignMessage msgSign = SkycoinSignMessage_init_zero;
 	strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
 	msgSign.address_n = 0;
 
-	// NOTE(denisacostaq@gmail.com): When
+	// NOTE(): When
 	uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
 	ResponseSkycoinSignMessage *respSign = (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
 	msgSkycoinSignMessageImpl(&msgSign, respSign);
@@ -237,7 +237,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedM
 	Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
 	err = msgSkycoinCheckMessageSignatureImpl(&checkMsg, successRespCheck, failRespCheck);
 
-	// NOTE(denisacostaq@gmail.com): Then
+	// NOTE(): Then
 	ck_assert_int_ne(ErrOk, err);
 	ck_assert(failRespCheck->has_message);
 	int address_diff = strncmp(
@@ -250,7 +250,7 @@ END_TEST
 
 START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage)
 {
-	// NOTE(denisacostaq@gmail.com): Given
+	// NOTE(): Given
 	forceGenerateMnemonic();
 	SkycoinAddress msgSkyAddress = SkycoinAddress_init_zero;
 	msgSkyAddress.address_n = 1;
@@ -259,7 +259,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage
 	ErrCode_t err = msgSkycoinAddressImpl(&msgSkyAddress, respAddress);
 	ck_assert_int_eq(ErrOk, err);
 	ck_assert_int_eq(respAddress->addresses_count, 1);
-	// NOTE(denisacostaq@gmail.com): `raw_msg` hash become from:
+	// NOTE(): `raw_msg` hash become from:
 	// https://github.com/skycoin/skycoin/blob/develop/src/cipher/testsuite/testdata/input-hashes.golden
 	char raw_msg[] = {
 		"66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"};
@@ -267,7 +267,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage
 	strncpy(msgSign.message, raw_msg, sizeof(msgSign.message));
 	msgSign.address_n = 0;
 
-	// NOTE(denisacostaq@gmail.com): When
+	// NOTE(): When
 	uint8_t msg_resp_sign[MSG_OUT_SIZE] __attribute__ ((aligned)) = {0};
 	ResponseSkycoinSignMessage *respSign = (ResponseSkycoinSignMessage *) (void *) msg_resp_sign;
 	msgSkycoinSignMessageImpl(&msgSign, respSign);
@@ -283,7 +283,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage
 	Failure *failRespCheck = (Failure *) (void *) msg_fail_resp_check;
 	err = msgSkycoinCheckMessageSignatureImpl(&checkMsg, successRespCheck, failRespCheck);
 
-	// NOTE(denisacostaq@gmail.com): Then
+	// NOTE(): Then
 	ck_assert_int_ne(ErrOk, err);
 	ck_assert(failRespCheck->has_message);
 	int address_diff = strncmp(


### PR DESCRIPTION
refs #151 

Changes:
- Only sign transaction inputs with address `index` field set
- Consistent error messages in `ApplySettings` message handler

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
yes , related to PR skycoin/hardware-wallet-protob#37 

Requires testing
yes

... needs tests ...
