### PR TITLE
refs #151 Differentate failure messages in ApplySettings

### DIFF
--- a/tiny-firmware/firmware/error.h
+++ b/tiny-firmware/firmware/error.h
@@ -71,6 +71,7 @@ enum ErrCode
 	ErrUserConfirmation = ERROR_CODE(PkgGeneric, ReasonUserConfirmation), /*!< User confirmation required to complete action */
 	ErrInvalidChecksum = ERROR_CODE(PkgGeneric, ReasonInvalidChecksum), /*!< Checksum verification failed */
 	ErrActionCancelled = ERROR_CODE(PkgGeneric, ReasonActionCancelled), /*!< Action cancelled by user */
+	ErrPreconditionFailed = ERROR_CODE(PkgGeneric, ReasonInvalidState), /*!< Message precondition failed */
 	ErrPinRequired = ERROR_CODE(PkgPinChk, ReasonInvalidState),          /*!< Action requires PIN and is not configured */
 	ErrPinMismatch = ERROR_CODE(PkgPinChk, ReasonValueError),          /*!< Action requires PIN and it didn't match */
 	ErrPinCancelled = ERROR_CODE(PkgPinChk, ReasonActionCancelled), /*!< Action requires PIN and was cancelled by user */

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -73,6 +73,12 @@ void fsm_sendResponseFromErrCode(ErrCode_t err, const char *successMsg, const ch
 				failMsg = _("Invalid argument");
 			}
 			break;
+		case ErrPreconditionFailed:
+			failure = FailureType_Failure_DataError;
+			if (failMsg == NULL) {
+				failMsg = _("Precondition failed");
+			}
+			break;
 		case ErrIndexValue:
 			failure = FailureType_Failure_DataError;
 			if (failMsg == NULL) {
@@ -265,7 +271,7 @@ void fsm_msgApplySettings(ApplySettings *msg)
 	ErrCode_t err = msgApplySettingsImpl(msg);
 	char *failMsg = NULL;
 	switch (err) {
-		case ErrInvalidArg:
+		case ErrPreconditionFailed:
 			failMsg = _("No setting provided");
 			break;
 		default:

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -245,7 +245,7 @@ ErrCode_t msgApplySettingsImpl(ApplySettings *msg)
 	_Static_assert(
 		sizeof(msg->label) == DEVICE_LABEL_SIZE,
 		"device label size inconsitent betwen protocol and final storage");
-	CHECK_PARAM_RET_ERR_CODE(msg->has_label || msg->has_language || msg->has_use_passphrase || msg->has_homescreen,
+	CHECK_PRECONDITION_RET_ERR_CODE(msg->has_label || msg->has_language || msg->has_use_passphrase || msg->has_homescreen,
 				_("No setting provided"));
 	if (msg->has_label) {
 		storage_setLabel(msg->label);

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -83,6 +83,18 @@
 		return ErrInvalidArg; \
 	}
 
+#define CHECK_PRECONDITION(cond, errormsg) \
+	if (!(cond)) { \
+		fsm_sendFailure(FailureType_Failure_DataError, (errormsg)); \
+		layoutHome(); \
+		return; \
+	}
+
+#define CHECK_PRECONDITION_RET_ERR_CODE(cond, errormsg) \
+	if (!(cond)) { \
+		return ErrPreconditionFailed; \
+	}
+
 #define CHECK_BUTTON_PROTECT \
 	if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) { \
 		fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL); \

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -381,32 +381,32 @@ START_TEST(test_msgApplySettingsNoSettingsFailure)
 
 	// No fields set
 	ApplySettings msg = ApplySettings_init_zero;
-	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrInvalidArg);
+	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrPreconditionFailed);
 
 	// label value set but all has_* unset
 	memset(&msg, 0, sizeof(msg));
 	char raw_label[] = {
 		"my custom device label"};
 	strncpy(msg.label, raw_label, sizeof(msg.label));
-	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrInvalidArg);
+	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrPreconditionFailed);
 
 	// use_passphrase value set but all has_* unset
 	memset(&msg, 0, sizeof(msg));
 	msg.use_passphrase = true;
-	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrInvalidArg);
+	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrPreconditionFailed);
 
 	// language value set but all has_* unset
 	memset(&msg, 0, sizeof(msg));
 	char language[] = {
 		"english"};
 	strncpy(msg.language, language, sizeof(msg.language));
-	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrInvalidArg);
+	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrPreconditionFailed);
 
 	// All values set but all has_* unset
 	memset(&msg, 0, sizeof(msg));
 	strncpy(msg.label, raw_label, sizeof(msg.label));
 	strncpy(msg.language, language, sizeof(msg.language));
-	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrInvalidArg);
+	ck_assert_int_eq(msgApplySettingsImpl(&msg), ErrPreconditionFailed);
 }
 END_TEST
 


### PR DESCRIPTION
refs #151 

Changes:
- Failure message for invalid language values is `Invaid argument`
- Failure message for no settings is `No settings provided`

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
yes

these are not captured on `fsm_impl.c` since it's beyond the scope of `*Impl` message handlers.
