### PR TITLE
fixes #188 - Fix pin codes with bad chars and equal length pass the pin check

### DIFF
--- a/tiny-firmware/Makefile
+++ b/tiny-firmware/Makefile
@@ -35,6 +35,7 @@ TEST_OBJS += firmware/test_fsm.o
 TEST_OBJS += firmware/test_droplet.o
 TEST_OBJS += firmware/test_main.o
 TEST_OBJS += firmware/test_many_address_golden.o
+TEST_OBJS += firmware/test_protect.o
 #end test_skyhw
 
 ifneq ($(EMULATOR),1)

--- a/tiny-firmware/firmware/pinmatrix.c
+++ b/tiny-firmware/firmware/pinmatrix.c
@@ -57,18 +57,23 @@ void pinmatrix_start(const char *text)
 	pinmatrix_draw(text);
 }
 
-void pinmatrix_done(char *pin)
-{
+void translate_pin_code(const char *matrix, char *pin) {
 	int k, i = 0;
 	while (pin && pin[i]) {
 		k = pin[i] - '1';
 		if (k >= 0 && k <= 8) {
-			pin[i] = pinmatrix_perm[k];
+			pin[i] = matrix[k];
 		} else {
-			pin[i] = 'X';
+			pin[i] = 0;
+			break;
 		}
 		i++;
 	}
+}
+
+void pinmatrix_done(char *pin)
+{
+	translate_pin_code(pinmatrix_perm, pin);
 	memset(pinmatrix_perm, 'X', sizeof(pinmatrix_perm) - 1);
 }
 

--- a/tiny-firmware/firmware/pinmatrix.h
+++ b/tiny-firmware/firmware/pinmatrix.h
@@ -20,8 +20,9 @@
 #ifndef __PINMATRIX_H__
 #define __PINMATRIX_H__
 
-void pinmatrix_start(const char *text);
-void pinmatrix_done(char *pin);
+void pinmatrix_start(const char *);
+void translate_pin_code(const char *, char *);
+void pinmatrix_done(char *);
 const char *pinmatrix_get(void);
 
 #endif

--- a/tiny-firmware/firmware/protect.c
+++ b/tiny-firmware/firmware/protect.c
@@ -234,7 +234,7 @@ bool protectChangePinEx(const char* (*funcRequestPin)(PinMatrixRequestType, cons
 
 	pin = funcRequestPin(PinMatrixRequestType_PinMatrixRequestType_NewSecond, _("Please re-enter new PIN:"));
 
-	const bool result = pin && (strncmp(pin_compare, pin, sizeof(pin_compare)) == 0);
+	const bool result = pin && *pin && (strncmp(pin_compare, pin, sizeof(pin_compare)) == 0);
 
 	if (result) {
 		storage_setPin(pin_compare);

--- a/tiny-firmware/firmware/test_main.c
+++ b/tiny-firmware/firmware/test_main.c
@@ -14,6 +14,7 @@
 #include "test_timer.h"
 #include "test_droplet.h"
 #include "test_fsm.h"
+#include "test_protect.h"
 
 // define test suite and cases
 Suite *test_suite(void)
@@ -23,6 +24,7 @@ Suite *test_suite(void)
 	suite_add_tcase(s, add_fsm_tests(tcase_create("fsm")));
 	suite_add_tcase(s, add_droplet_tests(tcase_create("droplet")));
 	suite_add_tcase(s, add_timer_tests(tcase_create("timer")));
+	suite_add_tcase(s, add_protect_tests(tcase_create("protect")));
 	return s;
 }
 

--- a/tiny-firmware/firmware/test_protect.c
+++ b/tiny-firmware/firmware/test_protect.c
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Skycoin project, https://skycoin.net/
+ *
+ * Copyright (C) 2018-2019 Skycoin Project
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include "pinmatrix.h"
+
+#include "test_protect.h"
+
+extern char pinmatrix_perm[10];
+
+START_TEST(test_pinMatrixDoneOK)
+{
+	char pin_code[4] = {0};
+	strcpy(pin_code, "953");
+	translate_pin_code("483926571", pin_code);
+	ck_assert_str_eq(pin_code, "123");
+
+	strcpy(pin_code, "294");
+	translate_pin_code("514386792", pin_code);
+	ck_assert_str_eq(pin_code, "123");
+
+	strcpy(pin_code, "672");
+	translate_pin_code("638591247", pin_code);
+	ck_assert_str_eq(pin_code, "123");
+}
+END_TEST
+
+START_TEST(test_pinMatrixDoneWithWrongChars)
+{
+	char pin_code[4] = {0};
+	strcpy(pin_code, "9A3");
+	translate_pin_code("483926571", pin_code);
+	ck_assert_str_eq(pin_code, "1");
+
+	strcpy(pin_code, "9BC");
+	translate_pin_code("483926571", pin_code);
+	ck_assert_str_eq(pin_code, "1");
+
+	strcpy(pin_code, "95D");
+	translate_pin_code("483926571", pin_code);
+	ck_assert_str_eq(pin_code, "12");
+
+	strcpy(pin_code, "B5D");
+	translate_pin_code("483926571", pin_code);
+	ck_assert_str_eq(pin_code, "");
+}
+END_TEST
+
+TCase *add_protect_tests(TCase *tc){
+	tcase_add_test(tc, test_pinMatrixDoneOK);
+	tcase_add_test(tc, test_pinMatrixDoneWithWrongChars);
+	return tc;
+}

--- a/tiny-firmware/firmware/test_protect.h
+++ b/tiny-firmware/firmware/test_protect.h
@@ -1,0 +1,14 @@
+/*
+ * This file is part of the Skycoin project, https://skycoin.net/
+ *
+ * Copyright (C) 2018-2019 Skycoin Project
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include <check.h>
+
+TCase *add_protect_tests(TCase *tc);


### PR DESCRIPTION
Fixes #188 

Changes:
- Cut pin code if invalid char found during matrix translation 

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
yes

see `test_protect.{c,h}`
