### PR TITLE
product string from SKYCOIN to Skywallet

### DIFF
--- a/tiny-firmware/bootloader/usb.c
+++ b/tiny-firmware/bootloader/usb.c
@@ -152,7 +152,7 @@ static const struct usb_config_descriptor config = {
 
 static const char *usb_strings[] = {
 	"SkycoinFoundation",
-	"SKYCOIN",
+	"Skywallet",
 	"", // empty serial
 };
 

--- a/tiny-firmware/bootloader/usb.c
+++ b/tiny-firmware/bootloader/usb.c
@@ -152,7 +152,7 @@ static const struct usb_config_descriptor config = {
 
 static const char *usb_strings[] = {
 	"SkycoinFoundation",
-	"Skywallet",
+	"SKYWALLET",
 	"", // empty serial
 };
 

--- a/tiny-firmware/firmware/usb.c
+++ b/tiny-firmware/firmware/usb.c
@@ -35,7 +35,7 @@
 
 #define USB_STRINGS \
 	X(MANUFACTURER, "SkycoinFoundation") \
-	X(PRODUCT, "Skywallet") \
+	X(PRODUCT, "SKYWALLET") \
 	X(SERIAL_NUMBER, storage_uuid_str) \
 	X(INTERFACE_MAIN,  "SKYCOIN Interface") 
 

--- a/tiny-firmware/firmware/usb.c
+++ b/tiny-firmware/firmware/usb.c
@@ -35,7 +35,7 @@
 
 #define USB_STRINGS \
 	X(MANUFACTURER, "SkycoinFoundation") \
-	X(PRODUCT, "SKYCOIN") \
+	X(PRODUCT, "Skywallet") \
 	X(SERIAL_NUMBER, storage_uuid_str) \
 	X(INTERFACE_MAIN,  "SKYCOIN Interface") 
 


### PR DESCRIPTION
Fixes #194 

Changes:
- `SKYCOIN` chnaged to `SKYWALLET` in product string.

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no
