### PR TITLE
refs #171 Boundary checks for address test cases

### DIFF
--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -565,7 +565,8 @@ START_TEST(test_msgSkycoinAddressesStartIndex)
 
 	msgAddr.has_start_index = true;
 	msgAddr.start_index = random32() % 100;
-	msgAddr.address_n = random32() % (100 - msgAddr.start_index);
+	msgAddr.address_n = random32() % (100 - msgAddr.start_index) + 1;
+	ck_assert_uint_ge(msgAddr.address_n, 1);
 	msgAddr.has_confirm_address = false;
 
 	ck_assert_int_eq(msgSkycoinAddressImpl(&msgAddr, resp), ErrOk);


### PR DESCRIPTION
Fixes #171

Changes:
- Ensure number of address is positive while testing Skycoin address generation

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
yes

happened in tests 
