### PR TITLE
Read device UUID ref #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Read device `uuid` from physical device.
 - Skycoin logo in bootloader mode
 - Enforce setting default device language to English
 - Use`protobuf` file definitions as a `git submodule` from http://github.com/skycoin/hardware-wallet-protob/

--- a/tiny-firmware/firmware/main.c
+++ b/tiny-firmware/firmware/main.c
@@ -9,6 +9,8 @@
  *
  */
 
+#include <libopencm3/stm32/desig.h>
+
 #include "skywallet.h"
 #include "oled.h"
 #include "bitmaps.h"
@@ -25,7 +27,9 @@
 #include "fastflash.h"
 #include "factory_test.h"
 #include "entropy.h"
+#include "memory.h"
 
+extern uint32_t device_uuid[STM32_UUID_LEN/sizeof(uint32_t)];
 int main(void)
 {
 #ifndef APPVER
@@ -47,8 +51,11 @@ int main(void)
 	timer_init();
 
 #ifdef APPVER
+	desig_get_unique_id(device_uuid);
 	// enable MPU (Memory Protection Unit)
 	mpu_config();
+#else
+	random_buffer((uint8_t *)device_uuid, sizeof(device_uuid));
 #endif
 
 #if DEBUG_LINK

--- a/tiny-firmware/firmware/storage.c
+++ b/tiny-firmware/firmware/storage.c
@@ -46,8 +46,9 @@
 /* magic constant to check validity of storage block */
 static const uint32_t storage_magic = 0x726f7473;   // 'stor' as uint32_t
 
-static uint32_t storage_uuid[12 / sizeof(uint32_t)];
-_Static_assert(sizeof(storage_uuid) == 12, "storage_uuid has wrong size");
+uint32_t device_uuid[STM32_UUID_LEN/sizeof(uint32_t)] = {0};
+#define storage_uuid device_uuid
+_Static_assert(sizeof(storage_uuid) == STM32_UUID_LEN, "storage_uuid has wrong size");
 
 Storage CONFIDENTIAL storageUpdate __attribute__((aligned(4)));
 _Static_assert((sizeof(storageUpdate) & 3) == 0, "storage unaligned");
@@ -247,8 +248,7 @@ void storage_init(void)
 
 void storage_generate_uuid(void)
 {
-	// set random uuid
-	random_buffer((uint8_t *)storage_uuid, sizeof(storage_uuid));
+	// NOTE(denisacostaq@gmail.com): storage_uuid is loaded from main function
 	data2hex(storage_uuid, sizeof(storage_uuid), storage_uuid_str);
 	reset_entropy_mix_256();
 }

--- a/tiny-firmware/memory.h
+++ b/tiny-firmware/memory.h
@@ -108,6 +108,8 @@ extern uint8_t *emulator_flash_base;
 #define FLASH_CODE_SECTOR_FIRST	4
 #define FLASH_CODE_SECTOR_LAST	7
 
+#define STM32_UUID_LEN 12
+
 #ifdef BOOTLOADER
 void memory_protect(void);
 #endif

--- a/tiny-firmware/serialno.c
+++ b/tiny-firmware/serialno.c
@@ -25,6 +25,7 @@
 #include "serialno.h"
 #include "util.h"
 #include "sha2.h"
+#include "memory.h"
 
 void fill_serialno_fixed(char *s)
 {
@@ -32,5 +33,5 @@ void fill_serialno_fixed(char *s)
 	desig_get_unique_id(uuid);
 	sha256_Raw((const uint8_t *)uuid, 12, (uint8_t *)uuid);
 	sha256_Raw((const uint8_t *)uuid, 32, (uint8_t *)uuid);
-	data2hex(uuid, 12, s);
+	data2hex(uuid, STM32_UUID_LEN, s);
 }

--- a/tiny-firmware/serialno.c
+++ b/tiny-firmware/serialno.c
@@ -29,7 +29,7 @@
 
 void fill_serialno_fixed(char *s)
 {
-	uint32_t uuid[8];
+	uint32_t uuid[STM32_UUID_LEN] = {0};
 	desig_get_unique_id(uuid);
 	sha256_Raw((const uint8_t *)uuid, 12, (uint8_t *)uuid);
 	sha256_Raw((const uint8_t *)uuid, 32, (uint8_t *)uuid);


### PR DESCRIPTION
Fixes #202
closes #100
closes #131 (@stdevIvr these number are the device uuid, coming physical device id with this pr, a random one in emulator, so can be different in emulator)

Changes:
- Read uuid from physical device.
- Please do not miss [this change](https://github.com/skycoin/hardware-wallet/pull/203/commits/a094382a48bc4f0dba3d5e690b3d042030a9fe97). ref #100 

Does this change need to mentioned in CHANGELOG.md?
yes

Requires changes in protobuf specs?
no

Requires testing
no