### PR TITLE
fixes #217 Fix bug determining firmware and bootloader version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .DEFAULT_GOAL := help
 .PHONY: clean-lib clean
 .PHONY: build-deps firmware-deps bootloader bootloader-mem-protect
+.PHONY: check check-version check-trng check-protob test
 .PHONY: firmware sign full-firmware-mem-protect full-firmware
-.PHONY: emulator run-emulator st-flash
+.PHONY: emulator run-emulator st-flash oflash
 .PHONY: bootloader-clean release-bootloader release-bootloader-mem-protect
 .PHONY: firmware-clean release-firmware
 .PHONY: release-combined release-combined-mem-protect
@@ -202,6 +203,10 @@ st-flash: ## Deploy (flash) firmware on physical wallet
 
 oflash: full-firmware
 	openocd -f openocd.cfg
+
+check-version:
+	echo "Bootloader : $(VERSION_BOOTLOADER_MAJOR).$(VERSION_BOOTLOADER_MAJOR).$(VERSION_BOOTLOADER_MAJOR)"
+	echo "Firmware   : $(VERSION_FIRMWARE_MAJOR).$(VERSION_FIRMWARE_MAJOR).$(VERSION_FIRMWARE_MAJOR)"
 
 check-trng: ## Run test tools over random buffers
 	make -C trng-test trng-generate-buffers

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 .PHONY: clean-lib clean
 .PHONY: build-deps firmware-deps bootloader bootloader-mem-protect
-.PHONY: check check-version check-trng check-protob test
+.PHONY: check check-version check-trng check-protob test check-ver
 .PHONY: firmware sign full-firmware-mem-protect full-firmware
 .PHONY: emulator run-emulator st-flash oflash
 .PHONY: bootloader-clean release-bootloader release-bootloader-mem-protect
@@ -23,7 +23,7 @@ VERSION_BOOTLOADER       =$(shell cat tiny-firmware/bootloader/VERSION | tr -d v
 VERSION_BOOTLOADER_MAJOR =$(shell echo $(VERSION_BOOTLOADER) | cut -d. -f1)
 VERSION_BOOTLOADER_MINOR =$(shell echo $(VERSION_BOOTLOADER) | cut -d. -f2)
 VERSION_BOOTLOADER_PATCH =$(shell echo $(VERSION_BOOTLOADER) | cut -d. -f3)
-VERSION_FIRMWARE_RAW     =$(shell ./ci-scripts/version.sh)
+VERSION_FIRMWARE_RAW     =$(shell cat tiny-firmware/VERSION)
 VERSION_FIRMWARE_MAJOR   =$(shell echo $(VERSION_FIRMWARE_RAW) | tr -d v | cut -d. -f1)
 VERSION_FIRMWARE_MINOR   =$(shell echo $(VERSION_FIRMWARE_RAW) | cut -d. -f2)
 VERSION_FIRMWARE_PATCH   =$(shell echo $(VERSION_FIRMWARE_RAW) | cut -d. -f3)
@@ -204,9 +204,9 @@ st-flash: ## Deploy (flash) firmware on physical wallet
 oflash: full-firmware
 	openocd -f openocd.cfg
 
-check-version:
-	echo "Bootloader : $(VERSION_BOOTLOADER_MAJOR).$(VERSION_BOOTLOADER_MAJOR).$(VERSION_BOOTLOADER_MAJOR)"
-	echo "Firmware   : $(VERSION_FIRMWARE_MAJOR).$(VERSION_FIRMWARE_MAJOR).$(VERSION_FIRMWARE_MAJOR)"
+check-ver:
+	echo "Bootloader : $(VERSION_BOOTLOADER_MAJOR).$(VERSION_BOOTLOADER_MINOR).$(VERSION_BOOTLOADER_PATCH)"
+	echo "Firmware   : $(VERSION_FIRMWARE_MAJOR).$(VERSION_FIRMWARE_MINOR).$(VERSION_FIRMWARE_PATCH)"
 
 check-trng: ## Run test tools over random buffers
 	make -C trng-test trng-generate-buffers

--- a/ci-scripts/version.sh
+++ b/ci-scripts/version.sh
@@ -8,7 +8,7 @@ then
         version=$(cat ./tiny-firmware/VERSION 2> /dev/null)
         if [ $? -ne 0 ]
         then
-            version='unknow'
+            version='unknown'
         fi
     fi
 fi


### PR DESCRIPTION
Fixes #217 

Changes:
- Do not read version from git SHA1 due to [failures](https://travis-ci.org/simelo/skycoin-hardware-wallet-js/jobs/530050283#L2340-L2357) . 

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no
