### PR TITLE
[firmware] fixes #228 - Include type of message success / failure is sent for

### DIFF
--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -663,5 +663,4 @@ void fsm_msgEntropyAck(EntropyAck* msg)
         fsm_sendFailure(FailureType_Failure_FirmwareError, _("Entropy ack failed."), &msgtype);
         break;
     }
-    layoutHome();
 }

--- a/tiny-firmware/firmware/fsm.h
+++ b/tiny-firmware/firmware/fsm.h
@@ -25,9 +25,9 @@
 
 // message functions
 
-void fsm_sendSuccess(const char* text);
+void fsm_sendSuccess(const char* text, MessageType* msgtype);
 
-void fsm_sendFailure(FailureType code, const char* text);
+void fsm_sendFailure(FailureType code, const char* text, MessageType* msgtype);
 
 void fsm_msgInitialize(Initialize* msg);
 void fsm_msgGetFeatures(GetFeatures* msg);

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -29,7 +29,7 @@
 
 #define CHECK_INITIALIZED                                          \
     if (!storage_isInitialized()) {                                \
-        fsm_sendFailure(FailureType_Failure_NotInitialized, NULL); \
+        fsm_sendFailure(FailureType_Failure_NotInitialized, NULL, 0); \
         return;                                                    \
     }
 
@@ -40,7 +40,7 @@
 
 #define CHECK_NOT_INITIALIZED                                                                                        \
     if (storage_isInitialized()) {                                                                                   \
-        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Device is already initialized. Use Wipe first.")); \
+        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Device is already initialized. Use Wipe first."), 0); \
         return;                                                                                                      \
     }
 
@@ -73,7 +73,7 @@
 
 #define CHECK_PARAM(cond, errormsg)                                 \
     if (!(cond)) {                                                  \
-        fsm_sendFailure(FailureType_Failure_DataError, (errormsg)); \
+        fsm_sendFailure(FailureType_Failure_DataError, (errormsg), 0); \
         layoutHome();                                               \
         return;                                                     \
     }
@@ -85,7 +85,7 @@
 
 #define CHECK_PRECONDITION(cond, errormsg)                          \
     if (!(cond)) {                                                  \
-        fsm_sendFailure(FailureType_Failure_DataError, (errormsg)); \
+        fsm_sendFailure(FailureType_Failure_DataError, (errormsg), 0); \
         layoutHome();                                               \
         return;                                                     \
     }
@@ -97,7 +97,7 @@
 
 #define CHECK_BUTTON_PROTECT                                                  \
     if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) { \
-        fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);           \
+        fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL, 0);           \
         layoutHome();                                                         \
         return;                                                               \
     }
@@ -110,7 +110,7 @@
 
 #define CHECK_MNEMONIC                                                              \
     if (storage_hasMnemonic() == false) {                                           \
-        fsm_sendFailure(FailureType_Failure_AddressGeneration, "Mnemonic not set"); \
+        fsm_sendFailure(FailureType_Failure_AddressGeneration, "Mnemonic not set", 0); \
         layoutHome();                                                               \
         return;                                                                     \
     }
@@ -122,21 +122,21 @@
 
 #define CHECK_INPUTS(msg)                                                                           \
     if ((msg)->nbIn > 8) {                                                                          \
-        fsm_sendFailure(FailureType_Failure_InvalidSignature, _("Cannot have more than 8 inputs")); \
+        fsm_sendFailure(FailureType_Failure_InvalidSignature, _("Cannot have more than 8 inputs"), 0); \
         layoutHome();                                                                               \
         return;                                                                                     \
     }
 
 #define CHECK_OUTPUTS(msg)                                                                           \
     if ((msg)->nbOut > 8) {                                                                          \
-        fsm_sendFailure(FailureType_Failure_InvalidSignature, _("Cannot have more than 8 outputs")); \
+        fsm_sendFailure(FailureType_Failure_InvalidSignature, _("Cannot have more than 8 outputs"), 0); \
         layoutHome();                                                                                \
         return;                                                                                      \
     }
 
 #define CHECK_MNEMONIC_CHECKSUM                                                                     \
     if (!mnemonic_check(msg->mnemonic)) {                                                           \
-        fsm_sendFailure(FailureType_Failure_DataError, _("Mnemonic with wrong checksum provided")); \
+        fsm_sendFailure(FailureType_Failure_DataError, _("Mnemonic with wrong checksum provided"), 0); \
         layoutHome();                                                                               \
         return;                                                                                     \
     }

--- a/tiny-firmware/firmware/messages.c
+++ b/tiny-firmware/firmware/messages.c
@@ -171,7 +171,7 @@ void msg_process(char type, uint16_t msg_id, const pb_field_t* fields, uint8_t* 
     if (status) {
         MessageProcessFunc(type, 'i', msg_id, msg_data);
     } else {
-        fsm_sendFailure(FailureType_Failure_DataError, stream.errmsg);
+        fsm_sendFailure(FailureType_Failure_DataError, stream.errmsg, 0);
     }
 }
 
@@ -195,11 +195,11 @@ void msg_read_common(char type, const uint8_t* buf, int len)
 
         fields = MessageFields(type, 'i', msg_id);
         if (!fields) { // unknown message
-            fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Unknown message read_common"));
+            fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Unknown message read_common"), 0);
             return;
         }
         if (msg_size > MSG_IN_SIZE) { // message is too big :(
-            fsm_sendFailure(FailureType_Failure_DataError, _("Message too big"));
+            fsm_sendFailure(FailureType_Failure_DataError, _("Message too big"), 0);
             return;
         }
 
@@ -273,11 +273,11 @@ void msg_read_tiny(const uint8_t* buf, int len)
         if (status) {
             msg_tiny_id = msg_id;
         } else {
-            fsm_sendFailure(FailureType_Failure_DataError, stream.errmsg);
+            fsm_sendFailure(FailureType_Failure_DataError, stream.errmsg, 0);
             msg_tiny_id = 0xFFFF;
         }
     } else {
-        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Unknown message read_tiny"));
+        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Unknown message read_tiny"), 0);
         msg_tiny_id = 0xFFFF;
     }
 }

--- a/tiny-firmware/firmware/protect.c
+++ b/tiny-firmware/firmware/protect.c
@@ -188,7 +188,7 @@ bool protectPin(bool use_cached)
             protectAbortedByInitialize = true;
             msg_tiny_id = 0xFFFF;
             usbTiny(0);
-            fsm_sendFailure(FailureType_Failure_PinCancelled, NULL);
+            fsm_sendFailure(FailureType_Failure_PinCancelled, NULL, 0);
             return false;
         }
         wait--;
@@ -197,11 +197,11 @@ bool protectPin(bool use_cached)
     const char* pin;
     pin = requestPin(PinMatrixRequestType_PinMatrixRequestType_Current, _("Please enter current PIN:"));
     if (!pin) {
-        fsm_sendFailure(FailureType_Failure_PinCancelled, NULL);
+        fsm_sendFailure(FailureType_Failure_PinCancelled, NULL, 0);
         return false;
     }
     if (!storage_increasePinFails(fails)) {
-        fsm_sendFailure(FailureType_Failure_PinInvalid, NULL);
+        fsm_sendFailure(FailureType_Failure_PinInvalid, NULL, 0);
         return false;
     }
     if (storage_containsPin(pin)) {
@@ -210,7 +210,7 @@ bool protectPin(bool use_cached)
         return true;
     } else {
         protectCheckMaxTry(storage_getPinWait(fails));
-        fsm_sendFailure(FailureType_Failure_PinInvalid, NULL);
+        fsm_sendFailure(FailureType_Failure_PinInvalid, NULL, 0);
         return false;
     }
 }

--- a/tiny-firmware/firmware/recovery.c
+++ b/tiny-firmware/firmware/recovery.c
@@ -167,7 +167,7 @@ static void recovery_done(void)
             storage_setMnemonic(new_mnemonic);
             memzero(new_mnemonic, sizeof(new_mnemonic));
             storage_update();
-            fsm_sendSuccess(_("Device recovered"));
+            fsm_sendSuccess(_("Device recovered"), 0);
         } else {
             // Inform the user about new mnemonic correctness (as well as whether it is the same as the current one).
             bool match = (storage_isInitialized() && storage_containsMnemonic(new_mnemonic));
@@ -178,7 +178,7 @@ static void recovery_done(void)
                     _("and MATCHES"),
                     _("the one in the device."), NULL, NULL, NULL);
                 protectButton(ButtonRequestType_ButtonRequest_Other, true);
-                fsm_sendSuccess(_("The seed is valid and matches the one in the device"));
+                fsm_sendSuccess(_("The seed is valid and matches the one in the device"), 0);
             } else {
                 layoutDialog(&bmp_icon_error, NULL, _("Confirm"), NULL,
                     _("The seed is valid"),
@@ -186,7 +186,7 @@ static void recovery_done(void)
                     _("the one in the device."), NULL, NULL, NULL);
                 protectButton(ButtonRequestType_ButtonRequest_Other, true);
                 fsm_sendFailure(FailureType_Failure_DataError,
-                    _("The seed is valid but does not match the one in the device"));
+                    _("The seed is valid but does not match the one in the device"), 0);
             }
         }
     } else {
@@ -199,7 +199,7 @@ static void recovery_done(void)
                 _("The seed is"), _("INVALID!"), NULL, NULL, NULL, NULL);
             protectButton(ButtonRequestType_ButtonRequest_Other, true);
         }
-        fsm_sendFailure(FailureType_Failure_DataError, _("Invalid seed, are words in correct order?"));
+        fsm_sendFailure(FailureType_Failure_DataError, _("Invalid seed, are words in correct order?"), 0);
     }
     awaiting_word = 0;
     layoutHome();
@@ -455,7 +455,7 @@ void recovery_init(uint32_t _word_count, bool passphrase_protection, bool pin_pr
 
     if (!dry_run) {
         if (pin_protection && !protectChangePin()) {
-            fsm_sendFailure(FailureType_Failure_PinMismatch, NULL);
+            fsm_sendFailure(FailureType_Failure_PinMismatch, NULL, 0);
             layoutHome();
             return;
         }
@@ -483,7 +483,7 @@ static void recovery_scrambledword(const char* word)
             if (!dry_run) {
                 session_clear(true);
             }
-            fsm_sendFailure(FailureType_Failure_ProcessError, _("Wrong word retyped"));
+            fsm_sendFailure(FailureType_Failure_ProcessError, _("Wrong word retyped"), 0);
             layoutHome();
             return;
         }
@@ -501,7 +501,7 @@ static void recovery_scrambledword(const char* word)
             if (!dry_run) {
                 session_clear(true);
             }
-            fsm_sendFailure(FailureType_Failure_DataError, _("Word not found in a wordlist"));
+            fsm_sendFailure(FailureType_Failure_DataError, _("Word not found in a wordlist"), 0);
             layoutHome();
             return;
         }
@@ -528,7 +528,7 @@ void recovery_word(const char* word)
         recovery_scrambledword(word);
         break;
     default:
-        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Not in Recovery mode"));
+        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Not in Recovery mode"), 0);
         break;
     }
 }

--- a/tiny-firmware/firmware/reset.c
+++ b/tiny-firmware/firmware/reset.c
@@ -56,14 +56,14 @@ void reset_init(bool display_random, uint32_t _strength, bool passphrase_protect
     if (display_random) {
         layoutDialogSwipe(&bmp_icon_info, _("Cancel"), _("Continue"), NULL, _("Internal entropy:"), ent_str[0], ent_str[1], ent_str[2], ent_str[3], NULL);
         if (!protectButton(ButtonRequestType_ButtonRequest_ResetDevice, false)) {
-            fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+            fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL, 0);
             layoutHome();
             return;
         }
     }
 
     if (pin_protection && !protectChangePin()) {
-        fsm_sendFailure(FailureType_Failure_PinMismatch, NULL);
+        fsm_sendFailure(FailureType_Failure_PinMismatch, NULL, 0);
         layoutHome();
         return;
     }
@@ -102,7 +102,7 @@ static char current_word[10];
 void reset_backup(bool separated)
 {
     if (!storage_needsBackup()) {
-        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Seed already backed up"));
+        fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Seed already backed up"), 0);
         return;
     }
 
@@ -135,7 +135,7 @@ void reset_backup(bool separated)
                     session_clear(true);
                 }
                 layoutHome();
-                fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+                fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL, 0);
                 return;
             }
             word_pos++;
@@ -146,7 +146,7 @@ void reset_backup(bool separated)
 
     if (!separated) {
         storage_update();
-        fsm_sendSuccess(_("Device successfully initialized"));
+        fsm_sendSuccess(_("Device successfully initialized"), 0);
     }
     layoutHome();
 }


### PR DESCRIPTION
Fixes #228 

 Changes:	
- Implement msg_type in success and failure responses
- Do not navigate to home screen after merging external entropy (beaks ongoing op)

Does this change need to mentioned in CHANGELOG.md?	
yes

Requires testing	
yes

Comments about testing , should you have some
No visible changes in test suite since message handler signatures did not change. Nonetheless will be tested in hw-js library
