### PR TITLE
fixes #245 - Release binary filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The firmware defines a contract enforced upon all client libraries communicating
 - **Minor version number** should be increased for releases adding incremental backwards-compatible changes to the firmware contract
 - **Patch version number** should be increased for bug fix releases and similar changes keeping firmware contract unchanged
 
-Firmware binary filename is `skywallet-firmware-v$(VERSION_FIRMWARE).bin`.
+Firmware binary filename is `skywallet-firmware-v$(VERSION_FIRMWARE).bin` e.g. `skywallet-firmware-v1.7.0.bin` .
 
 #### Bootloader version scheme
 
@@ -152,7 +152,7 @@ Bootloader versioning is independent and follows [semantic versioning](http://se
 - **Minor version number** is used for progressive backwards-compatible changes
 - **Patch version number** increased for bug fix releases
 
-Bootloader binary filename is `skywallet-bootloader-mem-protect-v$(VERSION_BOOTLOADER).bin` if compiled with memory protection enabled, else `skywallet-bootloader-no-memory-protect-v$(VERSION_BOOTLOADER).bin`.
+Bootloader binary filename is `skywallet-bootloader-mem-protect-v$(VERSION_BOOTLOADER).bin` if compiled with memory protection enabled, else `skywallet-bootloader-no-memory-protect-v$(VERSION_BOOTLOADER).bin`. For instance, `skywallet-bootloader-mem-protect-v1.0.2.bin` or  `skywallet-bootloader-no-memory-protect-v1.0.2.bin` could be bootloader file names.
 
 #### Versioning combined binary builds
 
@@ -165,7 +165,7 @@ The project releases production-ready binaries combining firmware and bootloader
 
 Version identifiers are strings including, in the same order, the numbers mentioned above separated by dots.
 
-Combined binary filename is `skywallet-full-mem-protect-$(COMBINED_VERSION).bin` if compiled with memory protection enabled, else `skywallet-full-no-mem-protect-$(COMBINED_VERSION).bin`.
+Combined binary filename is `skywallet-full-mem-protect-$(COMBINED_VERSION).bin` if compiled with memory protection enabled, else `skywallet-full-no-mem-protect-$(COMBINED_VERSION).bin` e.g. `skywallet-full-no-mem-protect-102.170.1.1.bin` and `skywallet-full-mem-protect-102.107.1.1.bin`.
 
 #### Versioning libraries
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The firmware defines a contract enforced upon all client libraries communicating
 - **Minor version number** should be increased for releases adding incremental backwards-compatible changes to the firmware contract
 - **Patch version number** should be increased for bug fix releases and similar changes keeping firmware contract unchanged
 
+Firmware binary filename is `skywallet-firmware-v$(VERSION_FIRMWARE).bin`.
+
 #### Bootloader version scheme
 
 Bootloader versioning is independent and follows [semantic versioning](http://semver.org) rules.
@@ -149,6 +151,8 @@ Bootloader versioning is independent and follows [semantic versioning](http://se
 - **Major version number** indicates major changes in bootloader code
 - **Minor version number** is used for progressive backwards-compatible changes
 - **Patch version number** increased for bug fix releases
+
+Bootloader binary filename is `skywallet-bootloader-mem-protect-v$(VERSION_BOOTLOADER).bin` if compiled with memory protection enabled, else `skywallet-bootloader-no-memory-protect-v$(VERSION_BOOTLOADER).bin`.
 
 #### Versioning combined binary builds
 
@@ -160,6 +164,8 @@ The project releases production-ready binaries combining firmware and bootloader
 - **Country Exit Code**: to cope with i18n and locale specific features. At present only a value of `en` is supported for English according to `ISO-639-1`.
 
 Version identifiers are strings including, in the same order, the numbers mentioned above separated by dots.
+
+Combined binary filename is `skywallet-full-mem-protect-$(COMBINED_VERSION).bin` if compiled with memory protection enabled, else `skywallet-full-no-mem-protect-$(COMBINED_VERSION).bin`.
 
 #### Versioning libraries
 


### PR DESCRIPTION


Fixes #245 

 Changes:	
- Document binary release filenames in version policies section of main README

Does this change need to mentioned in CHANGELOG.md?	
no

Requires testing	
no	
