### PR TITLE
Check message signature err msg ref #251

### DIFF
--- a/tiny-firmware/firmware/error.h
+++ b/tiny-firmware/firmware/error.h
@@ -86,7 +86,6 @@ enum ErrCode {
     ErrLowEntropy = ERROR_CODE(PkgEntropy, ReasonOutOfBounds),           /*!< Buffer entropy under 4.0 bits/symbol */
     ErrUnexpectedMessage = ERROR_CODE(PkgServer, ReasonInvalidState),    /*!< Server state loses path */
     ErrSignPreconditionFailed = ERROR_CODE(PkgSign, ReasonInvalidState), /*!< Signing precondition failed */
-    ErrInvalidPubKey = ERROR_CODE(PkgSign, ReasonArgumentError),         /*!< Invalid pub key */
     ErrInvalidSignature = ERROR_CODE(PkgSign, ReasonValueError),         /*!< Invalid Message Signature */
 };
 typedef enum ErrCode ErrCode_t;

--- a/tiny-firmware/firmware/error.h
+++ b/tiny-firmware/firmware/error.h
@@ -86,6 +86,7 @@ enum ErrCode {
     ErrLowEntropy = ERROR_CODE(PkgEntropy, ReasonOutOfBounds),           /*!< Buffer entropy under 4.0 bits/symbol */
     ErrUnexpectedMessage = ERROR_CODE(PkgServer, ReasonInvalidState),    /*!< Server state loses path */
     ErrSignPreconditionFailed = ERROR_CODE(PkgSign, ReasonInvalidState), /*!< Signing precondition failed */
+    ErrInvalidPubKey = ERROR_CODE(PkgSign, ReasonArgumentError),         /*!< Invalid pub key */
     ErrInvalidSignature = ERROR_CODE(PkgSign, ReasonValueError),         /*!< Invalid Message Signature */
 };
 typedef enum ErrCode ErrCode_t;

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -144,7 +144,12 @@ void fsm_sendResponseFromErrCode(ErrCode_t err, const char* successMsg, const ch
         failure = FailureType_Failure_UnexpectedMessage;
         break;
     case ErrSignPreconditionFailed:
+        failure = FailureType_Failure_InvalidSignature;
+        break;
     case ErrInvalidSignature:
+        if (failMsg == NULL) {
+            failMsg = _("Invalid signature.");
+        }
         failure = FailureType_Failure_InvalidSignature;
         break;
     default:

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -313,18 +313,18 @@ void fsm_msgSkycoinCheckMessageSignature(SkycoinCheckMessageSignature* msg)
       case ErrOk:
         msg_write(MessageType_MessageType_Success, successResp);
         layoutRawMessage("Verification success");
-        return;
+        break;
       case ErrInvalidSignature:
-        failureResp->code = FailureType_Failure_InvalidSignature;
+      case ErrInvalidPubKey:
         msg_write(MessageType_MessageType_Failure, failureResp);
         layoutRawMessage("Wrong signature");
         break;
       default:
-        failureResp->code = FailureType_Failure_FirmwareError;
+        strncpy(failureResp->message, _("Firmware error."), sizeof(failureResp->message));
+        msg_write(MessageType_MessageType_Failure, failureResp);
         layoutHome();
         break;
     }
-    msg_write(MessageType_MessageType_Failure, failureResp);
 }
 
 ErrCode_t requestConfirmTransaction(char* strCoin, char* strHour, TransactionSign* msg, uint32_t i)

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -146,6 +146,12 @@ void fsm_sendResponseFromErrCode(ErrCode_t err, const char* successMsg, const ch
     case ErrSignPreconditionFailed:
         failure = FailureType_Failure_InvalidSignature;
         break;
+    case ErrInvalidPubKey:
+        if (failMsg == NULL) {
+            failMsg = _("Unable to get pub key.");
+        }
+        failure = FailureType_Failure_InvalidSignature;
+        break;
     case ErrInvalidSignature:
         if (failMsg == NULL) {
             failMsg = _("Invalid signature.");

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -215,9 +215,8 @@ ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg,
         compute_sha256sum((const uint8_t *)msg->message, digest, strlen(msg->message));
     }
     tobuff(msg->signature, sign, sizeof(sign));
-
-    ErrCode_t ret = recover_pubkey_from_signed_message((char*)digest, sign, pubkey) == 0 ? ErrOk : ErrFailed;
-
+    ErrCode_t ret = recover_pubkey_from_signed_message(
+                (char*)digest, sign, pubkey) == 0 ? ErrOk : ErrInvalidPubKey;
     if (ret == ErrOk) {
         size_t pubkeybase58_size = sizeof(pubkeybase58);
         generate_base58_address_from_pubkey(pubkey, pubkeybase58, &pubkeybase58_size);
@@ -226,7 +225,7 @@ ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg,
             failureResp->has_message = true;
             ret = ErrInvalidSignature;
         } else {
-            memcpy(successResp->message, pubkeybase58, pubkeybase58_size);
+            strncpy(successResp->message, _("Verification success."), sizeof(successResp->message));
             successResp->has_message = true;
         }
     } else {

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -225,7 +225,7 @@ ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg,
             failureResp->has_message = true;
             ret = ErrInvalidSignature;
         } else {
-            strncpy(successResp->message, _("Verification success."), sizeof(successResp->message));
+            memcpy(successResp->message, pubkeybase58, pubkeybase58_size);
             successResp->has_message = true;
         }
     } else {

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -215,8 +215,7 @@ ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg,
         compute_sha256sum((const uint8_t *)msg->message, digest, strlen(msg->message));
     }
     tobuff(msg->signature, sign, sizeof(sign));
-    ErrCode_t ret = recover_pubkey_from_signed_message(
-                (char*)digest, sign, pubkey) == 0 ? ErrOk : ErrInvalidPubKey;
+    ErrCode_t ret = recover_pubkey_from_signed_message((char*)digest, sign, pubkey) == 0 ? ErrOk : ErrInvalidSignature;
     if (ret == ErrOk) {
         size_t pubkeybase58_size = sizeof(pubkeybase58);
         generate_base58_address_from_pubkey(pubkey, pubkeybase58, &pubkeybase58_size);

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -187,21 +187,20 @@ START_TEST(test_msgSkycoinCheckMessageSignatureOk)
     ResponseSkycoinSignMessage* respSign = (ResponseSkycoinSignMessage*)(void*)msg_resp_sign;
     msgSkycoinSignMessageImpl(&msgSign, respSign);
     SkycoinCheckMessageSignature checkMsg = SkycoinCheckMessageSignature_init_zero;
-    strncpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
+    memcpy(checkMsg.message, msgSign.message, sizeof(checkMsg.message));
     memcpy(checkMsg.address, respAddress->addresses[0], sizeof(checkMsg.address));
     memcpy(checkMsg.signature, respSign->signed_message, sizeof(checkMsg.signature));
-    uint8_t msg_success_resp_check[MSG_OUT_SIZE] __attribute__((aligned)) = {0};
-    uint8_t msg_fail_resp_check[MSG_OUT_SIZE] __attribute__((aligned)) = {0};
-    Success* successRespCheck = (Success*)(void*)msg_success_resp_check;
-    Failure* failRespCheck = (Failure*)(void*)msg_fail_resp_check;
-    err = msgSkycoinCheckMessageSignatureImpl(&checkMsg, successRespCheck, failRespCheck);
+    Success successRespCheck = Success_init_zero;
+    Failure failRespCheck = Failure_init_zero;
+    err = msgSkycoinCheckMessageSignatureImpl(
+                &checkMsg, &successRespCheck, &failRespCheck);
 
     // NOTE(): Then
     ck_assert_int_eq(ErrOk, err);
-    ck_assert(successRespCheck->has_message);
+    ck_assert(successRespCheck.has_message);
     int address_diff = strncmp(
         respAddress->addresses[0],
-        successRespCheck->message,
+        successRespCheck.message,
         sizeof(respAddress->addresses[0]));
     if (address_diff) {
         fprintf(stderr, "\nrespAddress->addresses[0]: ");
@@ -209,8 +208,8 @@ START_TEST(test_msgSkycoinCheckMessageSignatureOk)
             fprintf(stderr, "%c", respAddress->addresses[0][i]);
         }
         fprintf(stderr, "\nrespCheck->message: ");
-        for (size_t i = 0; i < sizeof(successRespCheck->message); ++i) {
-            fprintf(stderr, "%c", successRespCheck->message[i]);
+        for (size_t i = 0; i < sizeof(successRespCheck.message); ++i) {
+            fprintf(stderr, "%c", successRespCheck.message[i]);
         }
         fprintf(stderr, "\n");
     }

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -217,6 +217,25 @@ START_TEST(test_msgSkycoinCheckMessageSignatureOk)
 }
 END_TEST
 
+START_TEST(test_msgSkycoinCheckMessageSignatureCanNotGetPubKey)
+{
+    // NOTE Given
+    SkycoinCheckMessageSignature checkMsg = SkycoinCheckMessageSignature_init_zero;
+    strncpy(checkMsg.message, "msgSign.message", sizeof(checkMsg.message));
+    strncpy(checkMsg.address, "respAddress->addresses[0]", sizeof(checkMsg.address));
+    strncpy(checkMsg.signature, "respSign->signed_message", sizeof(checkMsg.signature));
+    Success successRespCheck = Success_init_zero;
+    Failure failRespCheck = Failure_init_zero;
+
+    // NOTE When
+    ErrCode_t err = msgSkycoinCheckMessageSignatureImpl(
+                &checkMsg, &successRespCheck, &failRespCheck);
+
+    // NOTE Then
+    ck_assert_int_eq(ErrInvalidPubKey, err);
+}
+END_TEST
+
 static void swap_char(char* ch1, char* ch2)
 {
     char tmp;
@@ -1235,6 +1254,7 @@ TCase* add_fsm_tests(TCase* tc)
     tcase_add_test(tc, test_msgGenerateMnemonicImplOk);
     tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFailIfItWasDone);
     tcase_add_test(tc, test_msgSkycoinCheckMessageSignatureOk);
+    tcase_add_test(tc, test_msgSkycoinCheckMessageSignatureCanNotGetPubKey);
     tcase_add_test(tc, test_msgGenerateMnemonicImplShouldFailForWrongSeedCount);
     tcase_add_test(tc, test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidSignedMessage);
     tcase_add_test(tc, test_msgSkycoinCheckMessageSignatureFailedAsExpectedForInvalidMessage);

--- a/tiny-firmware/firmware/test_fsm.c
+++ b/tiny-firmware/firmware/test_fsm.c
@@ -232,7 +232,7 @@ START_TEST(test_msgSkycoinCheckMessageSignatureCanNotGetPubKey)
                 &checkMsg, &successRespCheck, &failRespCheck);
 
     // NOTE Then
-    ck_assert_int_eq(ErrInvalidPubKey, err);
+    ck_assert_int_eq(ErrInvalidSignature, err);
 }
 END_TEST
 


### PR DESCRIPTION
Fixes #251

Changes:	
 - Fix error notification from `fsm_msgSkycoinCheckMessageSignature`.
 - Refactor `test_msgSkycoinCheckMessageSignatureOk` test.

Does this change need to mentioned in CHANGELOG.md?	
no	

Requires testing	
yes