### PR TITLE
[firmware] fixes #271 - Do not return empty strings for sigs

### DIFF
--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -409,6 +409,11 @@ ErrCode_t msgTransactionSignImpl(TransactionSign* msg, ErrCode_t (*funcConfirmTx
                 //layoutHome();
                 return ErrInvalidSignature;
             }
+        } else {
+            // Null sig
+            uint8_t signature[65];
+            memset(signature, 0, sizeof(signature));
+            tohex(resp->signatures[resp->signatures_count], signature, sizeof(signature));
         }
         resp->signatures_count++;
 #if EMULATOR


### PR DESCRIPTION

Fixes #271

 Changes:	
- Null signatures in `msgTransactionSignImpl` if input index not set

 Does this change need to mentioned in CHANGELOG.md?	
no	

Requires testing	
yes
