### PR TITLE
[WIP] Fix bootloader size

### DIFF
--- a/tiny-firmware/bootloader/Makefile
+++ b/tiny-firmware/bootloader/Makefile
@@ -52,7 +52,7 @@ CFLAGS += -DSIGNATURE_DEBUG=1
 else
 CFLAGS += -DSIGNATURE_DEBUG=0
 endif
-OPTFLAGS ?= -Os
+OPTFLAGS ?= -flto -Os 
 DEBUG ?= 0
 
 LDSCRIPT = bootloader-memory.ld

--- a/tiny-firmware/bootloader/Makefile
+++ b/tiny-firmware/bootloader/Makefile
@@ -52,7 +52,15 @@ CFLAGS += -DSIGNATURE_DEBUG=1
 else
 CFLAGS += -DSIGNATURE_DEBUG=0
 endif
-OPTFLAGS ?= -flto -Os 
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	OPTFLAGS ?= -flto -Os 
+endif
+ifeq ($(UNAME_S),Darwin)
+	OPTFLAGS ?= -Os 
+endif
+
 DEBUG ?= 0
 
 LDSCRIPT = bootloader-memory.ld

--- a/tiny-firmware/bootloader/firmware_align.py
+++ b/tiny-firmware/bootloader/firmware_align.py
@@ -5,7 +5,7 @@ import os
 fn = sys.argv[1]
 fs = os.stat(fn).st_size
 if fs > 32768:
-	raise Exception('bootloader has to be smaller than 32768 bytes')
+	raise Exception('Bootloader has to be smaller than 32768 bytes. Its size is {}'.format(fs))
 with open(fn, 'ab') as f:
 	f.write(b'\xFF' * (32768 - fs))
 	f.close()

--- a/tiny-firmware/supervise.c
+++ b/tiny-firmware/supervise.c
@@ -63,7 +63,7 @@ static uint32_t svhandler_flash_lock(void)
     return FLASH_SR;
 }
 
-extern volatile uint32_t system_millis;
+extern volatile uint64_t system_millis;
 
 void svc_handler_main(uint32_t* stack)
 {


### PR DESCRIPTION
Fixes #284 

 Changes:	
- Added `-flto` optimization flag for compilation

> This option runs the standard link-time optimizer. When invoked with source code, it generates GIMPLE (one of GCC’s internal representations) and writes it to special ELF sections in the object file. When the object files are linked together, all the function bodies are read from these ELF sections and instantiated as if they had been part of the same translation unit.

- Update debug string output(with bootloader size) and fix warning with type mismatch 
	

 Does this change need to mentioned in CHANGELOG.md?	
no	

 Requires testing	
yes


I have only tested this PR on Linux, so **it requires more testing on MacOS **
