### PR TITLE
fix full-firmware build fixes #291

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,13 +172,21 @@ tiny-firmware/skyfirmware.bin: firmware-deps
 sign: tiny-firmware/bootloader/libskycoin-crypto.so tiny-firmware/skyfirmware.bin ## Sign skycoin wallet firmware
 	tiny-firmware/bootloader/firmware_sign.py -s -f tiny-firmware/skyfirmware.bin
 
-full-firmware-mem-protect: bootloader-mem-protect firmware ## Build full firmware (RDP level 2)
+full-firmware-mem-protect: ## Build full firmware (RDP level 2)
+	make -C tiny-firmware/bootloader/ clean
+	make -C . bootloader-mem-protect
+	make -C tiny-firmware/bootloader/ clean
+	make -C . firmware
 	cp bootloader-memory-protected.bin tiny-firmware/bootloader/combine/bl.bin
 	cp tiny-firmware/skyfirmware.bin tiny-firmware/bootloader/combine/fw.bin
 	cd tiny-firmware/bootloader/combine/ ; $(PYTHON) prepare.py
 	mv tiny-firmware/bootloader/combine/combined.bin releases/full-firmware-memory-protected.bin
 
-full-firmware: bootloader firmware ## Build full firmware (RDP level 0)
+full-firmware: ## Build full firmware (RDP level 0)
+	make -C tiny-firmware/bootloader/ clean
+	make -C . bootloader
+	make -C tiny-firmware/bootloader/ clean
+	make -C . firmware
 	cp skybootloader-no-memory-protect.bin tiny-firmware/bootloader/combine/bl.bin
 	cp tiny-firmware/skyfirmware.bin tiny-firmware/bootloader/combine/fw.bin
 	cd tiny-firmware/bootloader/combine/ ; $(PYTHON) prepare.py

--- a/Makefile
+++ b/Makefile
@@ -172,21 +172,13 @@ tiny-firmware/skyfirmware.bin: firmware-deps
 sign: tiny-firmware/bootloader/libskycoin-crypto.so tiny-firmware/skyfirmware.bin ## Sign skycoin wallet firmware
 	tiny-firmware/bootloader/firmware_sign.py -s -f tiny-firmware/skyfirmware.bin
 
-full-firmware-mem-protect: ## Build full firmware (RDP level 2)
-	make -C tiny-firmware/bootloader/ clean
-	make -C . bootloader-mem-protect
-	make -C tiny-firmware/bootloader/ clean
-	make -C . firmware
+full-firmware-mem-protect: bootloader-mem-protect firmware ## Build full firmware (RDP level 2)
 	cp bootloader-memory-protected.bin tiny-firmware/bootloader/combine/bl.bin
 	cp tiny-firmware/skyfirmware.bin tiny-firmware/bootloader/combine/fw.bin
 	cd tiny-firmware/bootloader/combine/ ; $(PYTHON) prepare.py
 	mv tiny-firmware/bootloader/combine/combined.bin releases/full-firmware-memory-protected.bin
 
-full-firmware: ## Build full firmware (RDP level 0)
-	make -C tiny-firmware/bootloader/ clean
-	make -C . bootloader
-	make -C tiny-firmware/bootloader/ clean
-	make -C . firmware
+full-firmware: bootloader firmware ## Build full firmware (RDP level 0)
 	cp skybootloader-no-memory-protect.bin tiny-firmware/bootloader/combine/bl.bin
 	cp tiny-firmware/skyfirmware.bin tiny-firmware/bootloader/combine/fw.bin
 	cd tiny-firmware/bootloader/combine/ ; $(PYTHON) prepare.py

--- a/tiny-firmware/bootloader/Makefile
+++ b/tiny-firmware/bootloader/Makefile
@@ -2,26 +2,26 @@ NAME  = bootloader
 BOOTLOADER = 1
 
 #libskywallet.a
-OBJS += ../startup.o
-OBJS += ../buttons.o
-OBJS += ../layout.o
-OBJS += ../oled.o
-OBJS += ../rng.o
-OBJS += ../serialno.o
-OBJS += ../setup.o
-OBJS += ../supervise.o
-OBJS += ../timer.o
-OBJS += ../util.o
-OBJS += ../memory.o
+OBJS += startup.o
+OBJS += buttons.o
+OBJS += layout.o
+OBJS += oled.o
+OBJS += rng.o
+OBJS += serialno.o
+OBJS += setup.o
+OBJS += supervise.o
+OBJS += timer.o
+OBJS += util.o
+OBJS += memory.o
 OBJS += ../gen/bitmaps.o
 OBJS += ../gen/fonts.o
 #end libskywallet.a
 
 #skycoin-crypto
-OBJS += $(TOP_DIR)vendor/skycoin-crypto/skycoin_signature.o
-OBJS += $(TOP_DIR)vendor/skycoin-crypto/tools/curves.o
-OBJS += $(TOP_DIR)vendor/skycoin-crypto/tools/hmac.o
-OBJS += $(TOP_DIR)vendor/skycoin-crypto/tools/secp256k1.o
+OBJS += $(TOP_DIR)vendor/skycoin-crypto/skycoin_signature.small.o
+OBJS += $(TOP_DIR)vendor/skycoin-crypto/tools/curves.small.o
+OBJS += $(TOP_DIR)vendor/skycoin-crypto/tools/hmac.small.o
+OBJS += $(TOP_DIR)vendor/skycoin-crypto/tools/secp256k1.small.o
 # OBJS += $(TOP_DIR)vendor/skycoin-crypto/tools/bip32.o
 
 #end skycoin-crypto
@@ -62,3 +62,12 @@ include ../Makefile.include
 
 align: $(NAME).bin
 	./firmware_align.py $(NAME).bin
+
+%.o: ../%.c
+	$(CC) $(CFLAGS) -MMD -MP -o $@ -c $<
+
+%.o: ../%.s
+	$(AS) $(CPUFLAGS) -o $@ $<
+
+clean::
+	rm -rf *.o


### PR DESCRIPTION
Fixes #291	

Changes:	
-Creating different object files for firmware or bootloader.

Does this change need to mentioned in CHANGELOG.md?	
no	

Requires testing	
no

Additional info:
Some files are shared for bootloader and firmware for example [`setup.c` for firmware](https://github.com/skycoin/hardware-wallet/blob/12968889ca8d5e96201e2defeb92e2c137911f73/tiny-firmware/Makefile#L7) and [`setup.c` for bootloader](https://github.com/skycoin/hardware-wallet/blob/12968889ca8d5e96201e2defeb92e2c137911f73/tiny-firmware/bootloader/Makefile#L5). Those files are build with different flags for example if you build a firmware and then a bootloader, the result bootloader is too big because some files was no build with `-Os` (optimize for size), some similar strange behavior occur if you build the bootloader and then the firmware. This pr solve this issue but can be improved for the next milestone. 