### PR TITLE
[firmware] fixes #244 - Fix label erased after device recovery

### DIFF
--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -591,7 +591,7 @@ ErrCode_t msgRecoveryDeviceImpl(RecoveryDevice* msg, ErrCode_t (*funcConfirmReco
         msg->has_passphrase_protection && msg->passphrase_protection,
         msg->has_pin_protection && msg->pin_protection,
         msg->has_language ? msg->language : 0,
-        (msg->has_label && msg->label && strlen(msg->label) > 0)? msg->label: current_label,
+        (msg->has_label && strlen(msg->label) > 0)? msg->label: current_label,
         dry_run);
     return ErrOk;
 }

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -583,12 +583,15 @@ ErrCode_t msgRecoveryDeviceImpl(RecoveryDevice* msg, ErrCode_t (*funcConfirmReco
             return err;
         }
     }
+    char current_label[DEVICE_LABEL_SIZE];
+    strncpy(current_label, storage_getLabel(), sizeof(current_label));
+
     recovery_init(
         msg->has_word_count ? msg->word_count : 12,
         msg->has_passphrase_protection && msg->passphrase_protection,
         msg->has_pin_protection && msg->pin_protection,
         msg->has_language ? msg->language : 0,
-        msg->has_label ? msg->label : 0,
+        (msg->has_label && msg->label && strlen(msg->label) > 0)? msg->label: current_label,
         dry_run);
     return ErrOk;
 }


### PR DESCRIPTION
Fixes #244 

 Changes:	
- Use current label in `recovery_init` for not remove it if empty

Does this change need to mentioned in CHANGELOG.md?	
no	

Requires testing	
yes , but not possible now .
