### PR TITLE
[firmware] [bootloader] fixes #286 - Change names of RDP level

### DIFF
--- a/tiny-firmware/bootloader/bootloader.c
+++ b/tiny-firmware/bootloader/bootloader.c
@@ -186,11 +186,10 @@ static inline BITMAP invert_bitmap(BITMAP bm, uint8_t* data)
     return inverted;
 }
 
-extern uint8_t rdp_level;
 void bootloader_loop(void)
 {
     oledClear();
-    if (rdp_level != 2) {
+    if (memory_rdp_level() != 2) {
         // NOTE 48*64 is the size of the bmp_logo64 buffer.
         uint8_t bmp_logo64_data_inverted[48 * 64] = {0};
         BITMAP bmp_logo64_inverted =
@@ -223,7 +222,7 @@ int main(void)
 {
     setup();
     __stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
-    set_up_rdp_level();
+    memory_rdp_level();
     memory_protect();
     oledInit();
 

--- a/tiny-firmware/bootloader/usb.c
+++ b/tiny-firmware/bootloader/usb.c
@@ -28,6 +28,7 @@
 #include "buttons.h"
 #include "ecdsa.h"
 #include "layout.h"
+#include "memory.h"
 #include "memzero.h"
 #include "oled.h"
 #include "rng.h"
@@ -224,7 +225,6 @@ static void send_msg_failure(usbd_device* dev)
                64) != 64) {}
 }
 
-extern uint8_t rdp_level;
 static void send_msg_features(usbd_device* dev)
 {
     // response: Features message (id 17), payload len 39
@@ -258,7 +258,7 @@ static void send_msg_features(usbd_device* dev)
         // padding
         "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"};
     uint8_t fetOpts = 0;
-    switch (rdp_level) {
+    switch (memory_rdp_level()) {
     case 2:
         // https://github.com/skycoin/hardware-wallet-protob/blob/b3a2d50a55c6fb047b895bec27204e0abae38900/protob/messages/types.proto#L139
         fetOpts = (1 << 4);

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -284,7 +284,7 @@ ErrCode_t msgApplySettingsImpl(ApplySettings* msg)
 }
 
 #if !defined(EMULATOR) || !EMULATOR
-extern uint8_t rdp_level;
+#include "memory.h"
 #endif
 ErrCode_t msgGetFeaturesImpl(Features* resp)
 {
@@ -339,7 +339,7 @@ ErrCode_t msgGetFeaturesImpl(Features* resp)
 #if defined(EMULATOR) && EMULATOR
     resp->firmware_features |= FirmwareFeatures_IsEmulator;
 #else
-    resp->firmware_features |= (uint32_t)(rdp_level << FirmwareFeatures_IsEmulator);
+    resp->firmware_features |= (uint32_t)(memory_rdp_level() << FirmwareFeatures_IsEmulator);
 #endif
 
 #if DISABLE_GETENTROPY_CONFIRM

--- a/tiny-firmware/firmware/main.c
+++ b/tiny-firmware/firmware/main.c
@@ -51,7 +51,7 @@ int main(void)
     timer_init();
 
 #if !defined(EMULATOR) || EMULATOR == 0
-    set_up_rdp_level();
+    memory_rdp_level();
     desig_get_unique_id(storage_uuid);
     // enable MPU (Memory Protection Unit)
     mpu_config();

--- a/tiny-firmware/memory.c
+++ b/tiny-firmware/memory.c
@@ -59,18 +59,22 @@ int memory_bootloader_hash(uint8_t* hash)
     return 32;
 }
 
-uint8_t rdp_level;
-void set_up_rdp_level(void)
+uint8_t memory_rdp_level(void)
 {
-    switch (FLASH_OPTION_BYTES_1 & 0xFF00) {
-    case 0xCC00:
-        rdp_level = 2;
-        break;
-    case 0xAA00:
-        rdp_level = 0;
-        break;
-    default:
-        rdp_level = 1;
-        break;
+    static uint8_t rdp_level = 0x7F;
+
+    if (rdp_level > 2) {
+        switch (FLASH_OPTION_BYTES_1 & 0xFF00) {
+        case 0xCC00:
+            rdp_level = 2;
+            break;
+        case 0xAA00:
+            rdp_level = 0;
+            break;
+        default:
+            rdp_level = 1;
+            break;
+        }
     }
+    return rdp_level;
 }

--- a/tiny-firmware/memory.h
+++ b/tiny-firmware/memory.h
@@ -127,12 +127,12 @@ static inline void flash_write8(uint32_t addr, uint8_t byte)
 }
 
 /**
- * @brief rdp_level 	Reference STM32F205 Flash programming manual
+ * @brief memory_rdp_level	Reference STM32F205 Flash programming manual
  * revision 5 http://www.st.com/resource/en/programming_manual/cd00233952.pdf
  * Section 2.6 Option bytes
  * @return 0, 1, 2 as described in the manual for RDP level
  * [2.6.3 Read protection (RDP)](https://www.st.com/content/ccc/resource/technical/document/programming_manual/f7/7e/b9/a8/31/58/41/7b/CD00233952.pdf/files/CD00233952.pdf/jcr:content/translations/en.CD00233952.pdf)
  */
-void set_up_rdp_level(void);
+uint8_t memory_rdp_level(void);
 
 #endif


### PR DESCRIPTION
Fixes #286 

 Changes:	
- Implement `memory_rdp_level()`
- Remove `extern rdp_level` and `set_up_rdp_level()`

Does this change need to mentioned in CHANGELOG.md?	
no	

 Requires testing	
yes | no	

Impossible to test if not have one device
