### PR TITLE
add missing send failure case

### DIFF
--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -238,6 +238,12 @@ void fsm_sendFailure(FailureType code, const char* text, MessageType* msgtype)
         case FailureType_Failure_AddressGeneration:
             text = _("Failed to generate address");
             break;
+        case FailureType_Failure_FirmwarePanic:
+            text = _("Firmware panic");
+            break;
+        default:
+            text = _("Unknown failure error");
+            break;
         }
     }
     if (text) {


### PR DESCRIPTION
Fixes #310 

 Changes:	
- Add `FirmwarePanic` and `default` case in `sendFailure` function 

 Does this change need to mentioned in CHANGELOG.md?	
no	

 Requires testing	
no