### PR TITLE
Fix cancel backup ref #321

### DIFF
--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -621,9 +621,7 @@ void fsm_msgBackupDevice(BackupDevice* msg)
         fsm_sendFailure(FailureType_Failure_FirmwareError, _("Unexpected failure"), &msgtype);
         break;
     }
-    if (err != ErrActionCancelled) {
-        layoutHome();
-    }
+    layoutHome();
 }
 
 ErrCode_t confirmRecovery(void)

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -614,8 +614,7 @@ void fsm_msgBackupDevice(BackupDevice* msg)
         fsm_sendSuccess(_("Device backed up!"), &msgtype);
         break;
         CASE_SEND_FAILURE(ErrUnexpectedMessage, FailureType_Failure_UnexpectedMessage, _("Seed already backed up"))
-        // FIXME https://github.com/skycoin/hardware-wallet/issues/191#issuecomment-515221411
-        // CASE_SEND_FAILURE(ErrActionCancelled, FailureType_Failure_ActionCancelled, NULL)
+        CASE_SEND_FAILURE(ErrActionCancelled, FailureType_Failure_ActionCancelled, NULL)
         CASE_SEND_FAILURE(ErrUnfinishedBackup, FailureType_Failure_ActionCancelled, _("Backup operation did not finish properly."))
     default:
         fsm_sendFailure(FailureType_Failure_FirmwareError, _("Unexpected failure"), &msgtype);

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -621,7 +621,9 @@ void fsm_msgBackupDevice(BackupDevice* msg)
         fsm_sendFailure(FailureType_Failure_FirmwareError, _("Unexpected failure"), &msgtype);
         break;
     }
-    layoutHome();
+    if (err == ErrOk) {
+        layoutHome();
+    }
 }
 
 ErrCode_t confirmRecovery(void)

--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -614,7 +614,8 @@ void fsm_msgBackupDevice(BackupDevice* msg)
         fsm_sendSuccess(_("Device backed up!"), &msgtype);
         break;
         CASE_SEND_FAILURE(ErrUnexpectedMessage, FailureType_Failure_UnexpectedMessage, _("Seed already backed up"))
-        CASE_SEND_FAILURE(ErrActionCancelled, FailureType_Failure_ActionCancelled, NULL)
+        // FIXME https://github.com/skycoin/hardware-wallet/issues/191#issuecomment-515221411
+        // CASE_SEND_FAILURE(ErrActionCancelled, FailureType_Failure_ActionCancelled, NULL)
         CASE_SEND_FAILURE(ErrUnfinishedBackup, FailureType_Failure_ActionCancelled, _("Backup operation did not finish properly."))
     default:
         fsm_sendFailure(FailureType_Failure_FirmwareError, _("Unexpected failure"), &msgtype);

--- a/tiny-firmware/firmware/fsm_impl.c
+++ b/tiny-firmware/firmware/fsm_impl.c
@@ -581,9 +581,12 @@ ErrCode_t msgBackupDeviceImpl(BackupDevice* msg, ErrCode_t (*funcConfirmBackup)(
         //fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Seed already backed up"));
         return ErrUnexpectedMessage;
     }
-    reset_backup(true);
+    ErrCode_t err = reset_backup(true);
+    if (err != ErrOk) {
+      return err;
+    }
 
-    ErrCode_t err = funcConfirmBackup();
+    err = funcConfirmBackup();
     if (err != ErrOk) {
         return err;
     }

--- a/tiny-firmware/firmware/reset.c
+++ b/tiny-firmware/firmware/reset.c
@@ -109,12 +109,11 @@ ErrCode_t reset_entropy(void)
 
 static char current_word[10];
 
-// separated == true if called as a separate workflow via BackupMessage
-void reset_backup(bool separated)
+ErrCode_t reset_backup(bool separated)
 {
     if (!storage_needsBackup()) {
         fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Seed already backed up"), 0);
-        return;
+        return ErrUnexpectedMessage;
     }
 
     storage_setUnfinishedBackup(true);
@@ -147,7 +146,7 @@ void reset_backup(bool separated)
                 }
                 layoutHome();
                 fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL, 0);
-                return;
+                return ErrActionCancelled;
             }
             word_pos++;
         }
@@ -160,6 +159,7 @@ void reset_backup(bool separated)
         fsm_sendSuccess(_("Device successfully initialized"), 0);
     }
     layoutHome();
+    return ErrOk;
 }
 
 #if DEBUG_LINK

--- a/tiny-firmware/firmware/reset.h
+++ b/tiny-firmware/firmware/reset.h
@@ -29,7 +29,13 @@
 
 void reset_init(bool display_random, uint32_t _strength, bool passphrase_protection, bool pin_protection, const char* language, const char* label, bool skip_backup);
 ErrCode_t reset_entropy(void);
-void reset_backup(bool separated);
+
+/**
+ * @brief reset_backup create a device bckup
+ * @param separated true if called as a separate workflow via BackupMessage.
+ * @return Ok if success.
+ */
+ErrCode_t reset_backup(bool separated);
 uint32_t reset_get_int_entropy(uint8_t* entropy);
 const char* reset_get_word(void);
 


### PR DESCRIPTION
Fixes #321

Changes:	
- Change `reset_backup` signature to return an error.
- Check `reset_backup` ret value and go to home screen if non ok.
- Do not send cancel response from fsm layer.

Does this change need to mentioned in CHANGELOG.md?	
no	

Requires testing	
[later](https://github.com/skycoin/hardware-wallet/issues/178)