### PR TITLE
Run dieharder in resolve ambiguity mode ref #324

### DIFF
--- a/trng-test/Makefile
+++ b/trng-test/Makefile
@@ -20,7 +20,7 @@ ent: $(DATA:%.dat=%.ent)
 rngtest: $(DATA:%.dat=%.rngtest)
 
 %.dieharder: %.dat
-	dieharder -a -f $< > $@
+	dieharder -k 2 -Y 1 -a -f $< > $@
 
 %.ent: %.dat
 	ent $< > $@


### PR DESCRIPTION
Fixes #324

Changes:	
 - Run dieharder in resolve ambiguity mode([`-k 2 -Y 1`](https://www.systutorials.com/docs/linux/man/1-dieharder/)).

Does this change need to mentioned in CHANGELOG.md?	
no	

Requires testing	
no