### PR TITLE
Fixes #250 - Add boolean option for passphrase

### DIFF
--- a/tiny-firmware/firmware/fsm.c
+++ b/tiny-firmware/firmware/fsm.c
@@ -385,7 +385,7 @@ void fsm_msgSkycoinSignMessage(SkycoinSignMessage* msg)
     ResponseSkycoinAddress respAddr;
     uint8_t seckey[32] = {0};
     uint8_t pubkey[33] = {0};
-    ErrCode_t err = fsm_getKeyPairAtIndex(1, pubkey, seckey, &respAddr, msg->address_n);
+    ErrCode_t err = fsm_getKeyPairAtIndex(1, pubkey, seckey, &respAddr, msg->address_n, true);
     if (err != ErrOk) {
         fsm_sendResponseFromErrCode(err, NULL, _("Unable to get keys pair"), &msgtype);
         layoutHome();

--- a/tiny-firmware/firmware/fsm_impl.h
+++ b/tiny-firmware/firmware/fsm_impl.h
@@ -146,12 +146,12 @@
         return ErrInvalidValue;              \
     }
 
-ErrCode_t fsm_getKeyPairAtIndex(uint32_t nbAddress, uint8_t* pubkey, uint8_t* seckey, ResponseSkycoinAddress* respSkycoinAddress, uint32_t start_index);
+ErrCode_t fsm_getKeyPairAtIndex(uint32_t nbAddress, uint8_t* pubkey, uint8_t* seckey, ResponseSkycoinAddress* respSkycoinAddress, uint32_t start_index, bool with_passphrase);
 
 ErrCode_t msgGenerateMnemonicImpl(GenerateMnemonic* msg, void (*random_buffer_func)(uint8_t* buf, size_t len));
 ErrCode_t msgEntropyAckImpl(EntropyAck* msg);
 ErrCode_t msgSkycoinSignMessageImpl(SkycoinSignMessage* msg, ResponseSkycoinSignMessage* msg_resp);
-ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index, char* signed_message);
+ErrCode_t msgSignTransactionMessageImpl(uint8_t* message_digest, uint32_t index, char* signed_message, bool with_passphrase);
 ErrCode_t msgSkycoinAddressImpl(SkycoinAddress* msg, ResponseSkycoinAddress* resp);
 ErrCode_t msgSkycoinCheckMessageSignatureImpl(SkycoinCheckMessageSignature* msg, Success* successResp, Failure* failureResp);
 ErrCode_t msgApplySettingsImpl(ApplySettings* msg);


### PR DESCRIPTION
Fixes #250

 Changes:	
- Add `with_passphrase` option to `fsm_getKeyPairAtIndex`. This allows you to enable or not the use of a passphrase for mnemonic and, therefore, to use two generations of different addresses, as long as the device has the passphrase option enabled.
- In other uses of this function (`fsm_getKeyPairAtIndex`) outside the signing process, the argument` with_passphrase` is passed as `true`, because before this change that was the behavior. **Note that in the future the selection of passphrase or not, should be considered in the future in these cases.**

 Does this change need to mentioned in CHANGELOG.md?	
yes

 Requires testing	
yes

 Comments about testing , should you have some
