### PR TITLE
Added OpenOCD Debug support and Semihosting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,14 @@ st-flash: ## Deploy (flash) firmware on physical wallet
 oflash: full-firmware
 	openocd -f openocd.cfg
 
+odebug: full-firmware
+	## Debug works only on Linux at the moment
+	gnome-terminal --command="openocd -f interface/stlink-v2.cfg -f target/stm32f2x.cfg"
+	arm-none-eabi-gdb ./tiny-firmware/skyfirmware.elf \
+	-ex 'target remote localhost:3333' \
+	-ex 'monitor reset halt' \
+	-ex 'monitor arm semihosting enable'
+
 check-ver:
 	echo "Bootloader : $(VERSION_BOOTLOADER_MAJOR).$(VERSION_BOOTLOADER_MINOR).$(VERSION_BOOTLOADER_PATCH)"
 	echo "Firmware   : $(VERSION_FIRMWARE_MAJOR).$(VERSION_FIRMWARE_MINOR).$(VERSION_FIRMWARE_PATCH)"

--- a/tiny-firmware/Makefile.include
+++ b/tiny-firmware/Makefile.include
@@ -46,12 +46,18 @@ LDFLAGS  += --static \
             -Wl,--start-group \
             -lc \
             -lgcc \
-            -lnosys \
             -Wl,--end-group \
             -L$(TOOLCHAIN_DIR)/lib \
             -T$(LDSCRIPT) \
             -nostartfiles \
             -Wl,--gc-sections
+
+ifeq ($(SEMIHOSTING), 1)
+	LDFLAGS += -specs=rdimon.specs
+else
+	LDFLAGS += -lnosys
+endif
+
 CFLAGS += -DCONFIDENTIAL='__attribute__((section("confidential")))'
 
 endif

--- a/tiny-firmware/firmware/main.c
+++ b/tiny-firmware/firmware/main.c
@@ -29,6 +29,7 @@
 #include "tiny-firmware/firmware/entropy.h"
 #include "tiny-firmware/memory.h"
 #include "tiny-firmware/firmware/bootloader_integrity.h"
+#include "stdio.h"
 
 #ifdef __CYGWIN__
 #ifdef main
@@ -39,6 +40,7 @@
 extern uint32_t storage_uuid[STM32_UUID_LEN / sizeof(uint32_t)];
 
 int main(void) {
+  printf("Here\n");
 #if defined(EMULATOR) && EMULATOR == 1
     setup();
     __stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks

--- a/tiny-firmware/firmware/main.c
+++ b/tiny-firmware/firmware/main.c
@@ -40,7 +40,6 @@
 extern uint32_t storage_uuid[STM32_UUID_LEN / sizeof(uint32_t)];
 
 int main(void) {
-  printf("Here\n");
 #if defined(EMULATOR) && EMULATOR == 1
     setup();
     __stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks


### PR DESCRIPTION
Fixes #	

 Changes:	
-Now it is possible to debug project using OpenOCD. Also added semihosting support. Semihosting is feature, which alows you to redirect output from the "printf()" function into debugger console. To allow semihosting, set SEMIHOSTING=1

 Does this change need to mentioned in CHANGELOG.md?	
yes | no	

 Requires testing	
yes | no	

 Comments about testing , should you have some
