### PR TITLE
Fixes #350 Set python3 as default in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ FIRMWARE_SIGNATURE_PUB_KEYs = $(FIRMWARE_SIGNATURE_PUB_KEY1) $(FIRMWARE_SIGNATUR
 UNAME_S ?= $(shell uname -s)
 
 MAKE     ?= make
-PYTHON   ?= /usr/bin/python
+PYTHON   ?= /usr/bin/env python3 
 PIP      ?= pip
 PIPARGS  ?=
 COVERAGE ?= 0


### PR DESCRIPTION
Fixes #350 

This should solve any problems related to build firmware caused by python

 Changes:	
- Set in Makefile python3 as default

 Does this change need to mentioned in CHANGELOG.md?	
no	

 Requires testing	
no	
