### PR TITLE
Added hash checking skipping fixes #30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ skycoin-crypto-lib:
 
 firmware: tiny-firmware/skyfirmware.bin ## Build skycoin wallet firmware
 
+firmware-mem-protect: MEMORY_PROTECT=1
+firmware-mem-protect: firmware ## Build skycoin wallet firmware
+
 build-libc: tiny-firmware/bootloader/libskycoin-crypto.so ## Build the Skycoin cipher library for firmware
 
 release-emulator: clean emulator ## Build emulator in release mode.
@@ -164,12 +167,12 @@ tiny-firmware/bootloader/libskycoin-crypto.so:
 	$(MAKE) -C skycoin-api clean
 
 tiny-firmware/skyfirmware.bin: firmware-deps
-	$(MAKE) FIRMWARE_SIGNATURE_PUB_KEY1=$(FIRMWARE_SIGNATURE_PUB_KEY1) FIRMWARE_SIGNATURE_PUB_KEY2=$(FIRMWARE_SIGNATURE_PUB_KEY2) FIRMWARE_SIGNATURE_PUB_KEY3=$(FIRMWARE_SIGNATURE_PUB_KEY3) FIRMWARE_SIGNATURE_PUB_KEY4=$(FIRMWARE_SIGNATURE_PUB_KEY4) FIRMWARE_SIGNATURE_PUB_KEY5=$(FIRMWARE_SIGNATURE_PUB_KEY5) REVERSE_BUTTONS=1 VERSION_MAJOR=$(VERSION_FIRMWARE_MAJOR) VERSION_MINOR=$(VERSION_FIRMWARE_MINOR) VERSION_PATCH=$(VERSION_FIRMWARE_PATCH) GLOBAL_PATH=$(MKFILE_DIR) -C tiny-firmware/ add_meta_header
+	$(MAKE) MEMORY_PROTECT=$(MEMORY_PROTECT) FIRMWARE_SIGNATURE_PUB_KEY1=$(FIRMWARE_SIGNATURE_PUB_KEY1) FIRMWARE_SIGNATURE_PUB_KEY2=$(FIRMWARE_SIGNATURE_PUB_KEY2) FIRMWARE_SIGNATURE_PUB_KEY3=$(FIRMWARE_SIGNATURE_PUB_KEY3) FIRMWARE_SIGNATURE_PUB_KEY4=$(FIRMWARE_SIGNATURE_PUB_KEY4) FIRMWARE_SIGNATURE_PUB_KEY5=$(FIRMWARE_SIGNATURE_PUB_KEY5) REVERSE_BUTTONS=1 VERSION_MAJOR=$(VERSION_FIRMWARE_MAJOR) VERSION_MINOR=$(VERSION_FIRMWARE_MINOR) VERSION_PATCH=$(VERSION_FIRMWARE_PATCH) GLOBAL_PATH=$(MKFILE_DIR) -C tiny-firmware/ add_meta_header
 
 sign: tiny-firmware/bootloader/libskycoin-crypto.so tiny-firmware/skyfirmware.bin ## Sign skycoin wallet firmware
 	$(MAKE) FIRMWARE_SIGNATURE_PUB_KEY1=$(FIRMWARE_SIGNATURE_PUB_KEY1) FIRMWARE_SIGNATURE_PUB_KEY2=$(FIRMWARE_SIGNATURE_PUB_KEY2) FIRMWARE_SIGNATURE_PUB_KEY3=$(FIRMWARE_SIGNATURE_PUB_KEY3) FIRMWARE_SIGNATURE_PUB_KEY4=$(FIRMWARE_SIGNATURE_PUB_KEY4) FIRMWARE_SIGNATURE_PUB_KEY5=$(FIRMWARE_SIGNATURE_PUB_KEY5) -C tiny-firmware sign
 
-full-firmware-mem-protect: bootloader-mem-protect firmware ## Build full firmware (RDP level 2)
+full-firmware-mem-protect: bootloader-mem-protect firmware-mem-protect ## Build full firmware (RDP level 2)
 	cp bootloader-memory-protected.bin tiny-firmware/bootloader/combine/bl.bin
 	cp tiny-firmware/skyfirmware.bin tiny-firmware/bootloader/combine/fw.bin
 	cd tiny-firmware/bootloader/combine/ ; $(PYTHON) prepare.py

--- a/tiny-firmware/firmware/main.c
+++ b/tiny-firmware/firmware/main.c
@@ -45,12 +45,14 @@ int main(void) {
     __stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
     oledInit();
 #else  // defined(EMULATOR) && EMULATOR == 1
+#if defined(MEMORY_PROTECT) && MEMORY_PROTECT == 1
     if (!check_bootloader()) {
         layoutDialog(&bmp_icon_error, NULL, NULL, NULL, "Unknown bootloader", "detected.", NULL,
                      "Unplug your Skywallet",
                      "contact our support.", NULL);
         for (;;);
     }
+#endif
     setupApp();
     __stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
 #endif // defined(EMULATOR) && EMULATOR == 1


### PR DESCRIPTION
Fixes #30 

 Changes:	
- Skip bootloader's hash check, when compiling without memory protection  

 Does this change need to mentioned in CHANGELOG.md?	
 no	

 Requires testing	
 no	