### PR TITLE
Fixed no return to the home screen after signing_a_generic_message

### DIFF
--- a/tiny-firmware/firmware/fsm_skycoin.c
+++ b/tiny-firmware/firmware/fsm_skycoin.c
@@ -48,6 +48,7 @@
 #include "tiny-firmware/firmware/skyparams.h"
 #include "tiny-firmware/firmware/entropy.h"
 #include "tiny-firmware/firmware/fsm_skycoin_impl.h"
+#include "tiny-firmware/buttons.h"
 
 extern uint8_t msg_resp[MSG_OUT_SIZE] __attribute__((aligned));
 
@@ -99,14 +100,18 @@ void fsm_msgSkycoinSignMessage(SkycoinSignMessage *msg) {
     if (err == ErrOk) {
         msg_write(MessageType_MessageType_ResponseSkycoinSignMessage, resp);
         layoutRawMessage("Signature success");
+        do {
+            delay(100000);
+            buttonUpdate();
+        } while (!button.YesUp && !button.NoUp);
     } else {
         char *failMsg = NULL;
         if (err == ErrMnemonicRequired) {
             failMsg = _("Mnemonic not set");
         }
         fsm_sendResponseFromErrCode(err, NULL, failMsg, &msgtype);
-        layoutHome();
     }
+    layoutHome();
 }
 
 void fsm_msgSkycoinAddress(SkycoinAddress *msg) {


### PR DESCRIPTION
Fixes #13 	

 Changes:	
- Returns the user to the home screen after signing a generic message by pressing any button.

 Does this change need to mentioned in CHANGELOG.md?	
no	

 Requires testing	
no	

 Comments about testing, should you have some
