### PR TITLE
Fixed boundary of invalid recovery byte

### DIFF
--- a/ci-scripts/install-osx.sh
+++ b/ci-scripts/install-osx.sh
@@ -9,7 +9,9 @@ brew install check
 
 # Install build tools
 # TODO: Install tools in Debian's build-essentials ?
-brew install md5sha1sum curl unzip  gcc-arm-none-eabi
+brew install curl
+brew install unzip
+brew install gcc-arm-none-eabi
 brew install python3
 brew unlink python@2
 

--- a/skycoin-api/skycoin_crypto.c
+++ b/skycoin-api/skycoin_crypto.c
@@ -260,7 +260,7 @@ int skycoin_ecdsa_sign_digest(const uint8_t* priv_key, const uint8_t* digest, ui
     const curve_info* curve = get_curve_by_name(SECP256K1_NAME);
     uint8_t recid = 0;
     ret = ecdsa_sign_digest(curve->params, priv_key, digest, sig, &recid, NULL);
-    if (recid > 4) {
+    if (recid >= 4) {
         // This should never happen; we can abort() here, as a sanity check
         return -3;
     }


### PR DESCRIPTION
According to skycoin go implementation, recovery byte is invalid if it >= 4, but in hardware-wallet it is > 4. We need to keep our implementation the same, as in go.

 Changes:	
- invalid recovery byte boundary changed to >=4.   

 Does this change need to mentioned in CHANGELOG.md?	
 no	
